### PR TITLE
Add deployment and API key management features to OttoFMS CLI

### DIFF
--- a/.changeset/odd-tables-clean.md
+++ b/.changeset/odd-tables-clean.md
@@ -1,0 +1,5 @@
+---
+"@proofgeist/kit": minor
+---
+
+Allow deploying a demo file to your server instead of having to pick an existing file

--- a/cli/src/cli/add/data-source/deploy-demo-file.ts
+++ b/cli/src/cli/add/data-source/deploy-demo-file.ts
@@ -1,0 +1,96 @@
+import * as p from "@clack/prompts";
+
+import {
+  createDataAPIKeyWithCredentials,
+  getDeploymentStatus,
+  startDeployment,
+} from "~/cli/ottofms.js";
+
+export const filename = "ProofKitDemo.fmp12";
+
+export async function deployDemoFile({
+  url,
+  token,
+  operation,
+}: {
+  url: URL;
+  token: string;
+  operation: "install" | "replace";
+}): Promise<{ apiKey: string }> {
+  const deploymentJSON = {
+    scheduled: false,
+    label: "Install ProofKit Demo",
+    deployments: [
+      {
+        name: "Install ProofKit Demo",
+        source: {
+          type: "url",
+          url: "https://proofkit.dev/proofkit-demo/manifest.json",
+        },
+        fileOperations: [
+          {
+            target: {
+              fileName: filename,
+            },
+            operation,
+            source: {
+              fileName: "ProofKitDemo.fmp12",
+            },
+            location: {
+              folder: "default",
+              subFolder: "",
+            },
+          },
+        ],
+        concurrency: 1,
+        options: {
+          closeFilesAfterBuild: false,
+          keepFilesClosedAfterComplete: false,
+          transferContainerData: false,
+        },
+      },
+    ],
+    abortRemaining: false,
+  };
+
+  const spinner = p.spinner();
+  spinner.start("Deploying ProofKit Demo file...");
+
+  const {
+    response: { subDeploymentIds },
+  } = await startDeployment({
+    payload: deploymentJSON,
+    url,
+    token,
+  });
+
+  const deploymentId = subDeploymentIds[0]!;
+
+  while (true) {
+    // wait 2.5 seconds, then poll the status again
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+
+    const {
+      response: { status, running },
+    } = await getDeploymentStatus({
+      url,
+      token,
+      deploymentId,
+    });
+    if (!running) {
+      if (status !== "complete") throw new Error("Deployment didn't complete");
+      break;
+    }
+  }
+
+  const { apiKey } = await createDataAPIKeyWithCredentials({
+    filename,
+    username: "admin",
+    password: "admin",
+    url,
+  });
+
+  spinner.stop();
+
+  return { apiKey };
+}

--- a/cli/src/generators/auth.ts
+++ b/cli/src/generators/auth.ts
@@ -21,6 +21,13 @@ export async function addAuth({
   const settings = getSettings();
   if (settings.auth.type !== "none") {
     throw new Error("Auth already exists");
+  } else if (
+    !settings.dataSources.some((o) => o.type === "fm") &&
+    options.type === "fmaddon"
+  ) {
+    throw new Error(
+      "A FileMaker data source is required to use the FM Add-on Auth"
+    );
   }
 
   if (options.type === "clerk") {


### PR DESCRIPTION
Add deployment and API key management features to OttoFMS CLI

- Introduce new functions for creating API keys and managing deployments
- Add support for deploying demo FileMaker files during data source setup
- Implement Zod schema validation for deployment and status responses
- Enhance FileMaker data source configuration with demo file deployment option

changeset