### PR TITLE
Fix webviewer navigation file error

### DIFF
--- a/packages/cli/src/cli/remove/page.ts
+++ b/packages/cli/src/cli/remove/page.ts
@@ -18,9 +18,12 @@ import { abortIfCancel, ensureProofKitProject } from "../utils.js";
 const getExistingRoutes = (
   project: Project
 ): { label: string; href: string }[] => {
-  const sourceFile = project.addSourceFileAtPath(
-    path.join(state.projectDir, "src/app/navigation.tsx")
-  );
+  const navFilePath = path.join(state.projectDir, "src/app/navigation.tsx");
+
+  // If navigation file doesn't exist (e.g., webviewer apps), there are no nav routes to remove
+  if (!fs.existsSync(navFilePath)) return [];
+
+  const sourceFile = project.addSourceFileAtPath(navFilePath);
 
   const routes: { label: string; href: string }[] = [];
 
@@ -88,9 +91,12 @@ const getExistingRoutes = (
 };
 
 const removeRouteFromNav = async (project: Project, routeToRemove: string) => {
-  const sourceFile = project.addSourceFileAtPath(
-    path.join(state.projectDir, "src/app/navigation.tsx")
-  );
+  const navFilePath = path.join(state.projectDir, "src/app/navigation.tsx");
+
+  // Skip if there is no navigation file
+  if (!fs.existsSync(navFilePath)) return;
+
+  const sourceFile = project.addSourceFileAtPath(navFilePath);
 
   // Remove from primary routes
   const primaryRoutes = sourceFile
@@ -190,7 +196,7 @@ export const runRemovePageAction = async (routeName?: string) => {
       return p.cancel(`Page at ${routeName} does not exist`);
     }
 
-    // Remove from navigation first
+    // Remove from navigation first (if present)
     await removeRouteFromNav(project, routeName);
 
     // Remove the page directory

--- a/packages/cli/src/generators/route.ts
+++ b/packages/cli/src/generators/route.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { type RouteLink } from "index.js";
 import { SyntaxKind } from "ts-morph";
+import fs from "fs-extra";
 
 import { formatAndSaveSourceFiles, getNewProject } from "~/utils/ts-morph.js";
 
@@ -12,10 +13,13 @@ export async function addRouteToNav({
   projectDir: string;
   navType: "primary" | "secondary";
 }) {
+  const navFilePath = path.join(projectDir, "src/app/navigation.tsx");
+
+  // If the navigation file doesn't exist (e.g., WebViewer apps), skip adding to nav
+  if (!fs.existsSync(navFilePath)) return;
+
   const project = getNewProject(projectDir);
-  const sourceFile = project.addSourceFileAtPath(
-    path.join(projectDir, "src/app/navigation.tsx")
-  );
+  const sourceFile = project.addSourceFileAtPath(navFilePath);
   sourceFile
     .getVariableDeclaration(
       navType === "primary" ? "primaryRoutes" : "secondaryRoutes"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      '@proofkit/better-auth':
-        specifier: link:../../../../Library/pnpm/global/5/node_modules/@proofkit/better-auth
-        version: link:../../../../Library/pnpm/global/5/node_modules/@proofkit/better-auth
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.3
@@ -46,8 +42,8 @@ importers:
         specifier: ^1.2.10
         version: 1.2.10(@libsql/client@0.6.2)(@planetscale/database@1.19.0)(@types/react@19.1.8)(kysely@0.28.2)(magicast@0.3.5)(mysql2@3.14.1)(postgres@3.4.5)(react@19.1.0)
       '@proofkit/better-auth':
-        specifier: link:../../../../../../Library/pnpm/global/5/node_modules/@proofkit/better-auth
-        version: link:../../../../../../Library/pnpm/global/5/node_modules/@proofkit/better-auth
+        specifier: link:../../../Library/pnpm/global/5/node_modules/@proofkit/better-auth
+        version: link:../../../Library/pnpm/global/5/node_modules/@proofkit/better-auth
       '@proofkit/fmdapi':
         specifier: workspace:*
         version: link:../../packages/fmdapi


### PR DESCRIPTION
Guard CLI page add/remove commands against missing `src/app/navigation.tsx` to prevent errors in WebViewer apps.

---
<a href="https://cursor.com/background-agent?bcId=bc-a825acb5-ff2c-4986-9c7e-79aea61895a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a825acb5-ff2c-4986-9c7e-79aea61895a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

