### PR TITLE
fix execute script

### DIFF
--- a/.changeset/old-pots-lose.md
+++ b/.changeset/old-pots-lose.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/fmdapi": patch
+---
+
+Update executeScript method to infer layout name from client

--- a/packages/fmdapi/src/adapters/core.ts
+++ b/packages/fmdapi/src/adapters/core.ts
@@ -11,6 +11,8 @@ import type {
   Query,
   UpdateParams,
   UpdateResponse,
+  ScriptParams,
+  ScriptResponse,
 } from "../client-types.js";
 
 export type BaseRequest = {
@@ -44,7 +46,10 @@ export type ContainerUploadOptions = BaseRequest & {
     modId?: number;
   };
 };
-
+export type ExecuteScriptOptions = BaseRequest & {
+  script: string;
+  scriptParam?: string;
+};
 export type LayoutMetadataOptions = BaseRequest;
 
 export interface Adapter {
@@ -59,4 +64,6 @@ export interface Adapter {
   layoutMetadata: (
     opts: LayoutMetadataOptions,
   ) => Promise<LayoutMetadataResponse>;
+
+  executeScript: (opts: ExecuteScriptOptions) => Promise<ScriptResponse>;
 }

--- a/packages/fmdapi/src/adapters/fetch-base.ts
+++ b/packages/fmdapi/src/adapters/fetch-base.ts
@@ -17,6 +17,7 @@ import type {
   ContainerUploadOptions,
   CreateOptions,
   DeleteOptions,
+  ExecuteScriptOptions,
   FindOptions,
   GetOptions,
   LayoutMetadataOptions,
@@ -27,11 +28,6 @@ import type {
   BaseFetchAdapterOptions,
   GetTokenArguments,
 } from "./fetch-base-types.js";
-
-export type ExecuteScriptOptions = BaseRequest & {
-  script: string;
-  scriptParam?: string;
-};
 
 export class BaseFetchAdapter implements Adapter {
   protected server: string;

--- a/packages/fmdapi/src/client.ts
+++ b/packages/fmdapi/src/client.ts
@@ -1,4 +1,4 @@
-import type { Adapter } from "./adapters/core.js";
+import type { Adapter, ExecuteScriptOptions } from "./adapters/core.js";
 import type {
   CreateParams,
   CreateResponse,
@@ -80,6 +80,7 @@ function DataApi<
     update,
     layoutMetadata,
     containerUpload,
+    executeScript,
     ...otherMethods
   } = options.adapter;
 
@@ -125,6 +126,8 @@ function DataApi<
     query: Query<T> | Array<Query<T>>;
     timeout?: number;
   };
+
+  type ExecuteScriptArgs = Omit<ExecuteScriptOptions, "layout">;
 
   /**
    * List all records from a given layout, no find criteria applied.
@@ -516,6 +519,13 @@ function DataApi<
     return result;
   }
 
+  async function _executeScript(args: ExecuteScriptArgs & FetchOptions) {
+    return await executeScript({
+      ...args,
+      layout,
+    });
+  }
+
   return {
     ...otherMethods,
     layout: options.layout as Opts["layout"],
@@ -532,6 +542,7 @@ function DataApi<
     findAll,
     layoutMetadata: _layoutMetadata,
     containerUpload: _containerUpload,
+    executeScript: _executeScript,
   };
 }
 

--- a/packages/fmdapi/tests/client-methods.test.ts
+++ b/packages/fmdapi/tests/client-methods.test.ts
@@ -319,7 +319,6 @@ describe("other methods", () => {
     const resp = await client.executeScript({
       script: "script",
       scriptParam: param,
-      layout: client.layout,
     });
 
     expect(resp.scriptResult).toBe("result");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added executeScript to the Data API client to run scripts directly.
  - Layout is now inferred from the client, so you no longer need to pass it when executing scripts.
  - Supports optional script parameters.

- Tests
  - Updated tests to reflect layout inference in executeScript.

- Chores
  - Added changeset for a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->