### PR TITLE
fix link

### DIFF
--- a/apps/docs/content/docs/cli/guides/getting-started.mdx
+++ b/apps/docs/content/docs/cli/guides/getting-started.mdx
@@ -37,7 +37,7 @@ Your hosted FileMaker file must have an account with the `fmrest` priviledge set
 
 #### FileMaker Web Viewer
 
-If you intend to build for the FileMaker Web Viewer, the same requirements apply for FileMaker Server and OttoFMS as above. You will also need to make sure that your Full Access account has the `fmurlscript` priviledge enabled so the web code can trigger FileMaker scripts, making development a lot easier. For more details, see the [WebViewer Getting Started Guide](/webviewer/getting-started).
+If you intend to build for the FileMaker Web Viewer, the same requirements apply for FileMaker Server and OttoFMS as above. You will also need to make sure that your Full Access account has the `fmurlscript` priviledge enabled so the web code can trigger FileMaker scripts, making development a lot easier. For more details, see the [WebViewer Getting Started Guide](/docs/webviewer).
 
 #### Supabase
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated the FileMaker Web Viewer prerequisites page to use the current Getting Started Guide URL (/docs/webviewer) instead of the deprecated path. This change ensures readers land on the correct guide and avoids broken or outdated navigation. No other content modifications were made; all instructions and screenshots remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->