### PR TITLE
Switch to raw fetch

### DIFF
--- a/.changeset/seven-moose-yell.md
+++ b/.changeset/seven-moose-yell.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/better-auth": minor
+---
+
+Change underlying fetch implementation

--- a/packages/better-auth/package.json
+++ b/packages/better-auth/package.json
@@ -46,8 +46,6 @@
   "dependencies": {
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
-    "@better-fetch/fetch": "1.1.17",
-    "@better-fetch/logger": "^1.1.18",
     "@commander-js/extra-typings": "^14.0.0",
     "@tanstack/vite-config": "^0.2.0",
     "better-auth": "^1.2.10",
@@ -57,6 +55,7 @@
     "dotenv": "^16.5.0",
     "fs-extra": "^11.3.0",
     "neverthrow": "^8.2.0",
+    "odata-query": "^8.0.4",
     "prompts": "^2.4.2",
     "vite": "^6.3.4",
     "zod": "3.25.64"
@@ -64,6 +63,7 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/prompts": "^2.4.9",
+    "@vitest/ui": "^3.2.4",
     "fm-odata-client": "^3.0.1",
     "publint": "^0.3.12",
     "typescript": "^5.9.2",

--- a/packages/better-auth/src/adapter.ts
+++ b/packages/better-auth/src/adapter.ts
@@ -231,7 +231,7 @@ export const FileMakerAdapter = (
               $top: limit,
               $skip: offset,
               ...(sortBy
-                ? { $orderby: `"${sortBy.field}" ${sortBy.direction ?? "asc"}` }
+                ? { $orderby: `${sortBy.field}%20${sortBy.direction ?? "asc"}` }
                 : {}),
             },
             output: z.object({ value: z.array(z.any()) }),

--- a/packages/better-auth/src/cli/index.ts
+++ b/packages/better-auth/src/cli/index.ts
@@ -13,7 +13,7 @@ import { logger } from "better-auth";
 import prompts from "prompts";
 import chalk from "chalk";
 import { AdapterOptions } from "../adapter";
-import { createFmOdataFetch } from "../odata";
+import { createRawFetch } from "../odata";
 import "dotenv/config";
 
 async function main() {
@@ -64,7 +64,7 @@ async function main() {
       const betterAuthSchema = getAuthTables(config);
 
       const adapterConfig = (adapter.options as AdapterOptions).config;
-      const fetch = createFmOdataFetch({
+      const { fetch } = createRawFetch({
         ...adapterConfig.odata,
         auth:
           // If the username and password are provided in the CLI, use them to authenticate instead of what's in the config file.
@@ -74,6 +74,7 @@ async function main() {
                 password: options.password,
               }
             : adapterConfig.odata.auth,
+        logging: "verbose", // Enable logging for CLI operations
       });
 
       const migrationPlan = await planMigration(

--- a/packages/better-auth/src/odata/index.ts
+++ b/packages/better-auth/src/odata/index.ts
@@ -1,5 +1,3 @@
-import { createFetch, createSchema } from "@better-fetch/fetch";
-import { logger } from "@better-fetch/logger";
 import { logger as betterAuthLogger } from "better-auth";
 import { err, ok, Result } from "neverthrow";
 import { z } from "zod/v4";
@@ -20,78 +18,6 @@ export type FmOdataConfig = {
   logging?: true | "verbose" | "none";
 };
 
-const schema = createSchema({
-  /**
-   * Create a new table
-   */
-  "@post/FileMaker_Tables": {
-    input: z.object({ tableName: z.string(), fields: z.array(z.any()) }),
-  },
-  /**
-   * Add fields to a table
-   */
-  "@patch/FileMaker_Tables/:tableName": {
-    params: z.object({ tableName: z.string() }),
-    input: z.object({ fields: z.array(z.any()) }),
-  },
-  /**
-   * Delete a table
-   */
-  "@delete/FileMaker_Tables/:tableName": {
-    params: z.object({ tableName: z.string() }),
-  },
-  /**
-   * Delete a field from a table
-   */
-  "@delete/FileMaker_Tables/:tableName/:fieldName": {
-    params: z.object({ tableName: z.string(), fieldName: z.string() }),
-  },
-});
-
-export function createFmOdataFetch(args: FmOdataConfig) {
-  const result = validateUrl(args.serverUrl);
-
-  if (result.isErr()) {
-    throw new Error("Invalid server URL");
-  }
-  let baseURL = result.value.origin;
-  if ("apiKey" in args.auth) {
-    baseURL += `/otto`;
-  }
-  baseURL += `/fmi/odata/v4/${args.database}`;
-
-  return createFetch({
-    baseURL,
-    auth:
-      "apiKey" in args.auth
-        ? { type: "Bearer", token: args.auth.apiKey }
-        : {
-            type: "Basic",
-            username: args.auth.username,
-            password: args.auth.password,
-          },
-    onError: (error) => {
-      console.error("url", error.request.url.toString());
-      console.log(error.error);
-      console.log("error.request.body", JSON.stringify(error.request.body));
-    },
-    schema,
-    plugins: [
-      logger({
-        verbose: args.logging === "verbose",
-        enabled: args.logging === "verbose" || !!args.logging,
-        console: {
-          fail: (...args) => betterAuthLogger.error("better-fetch", ...args),
-          success: (...args) => betterAuthLogger.info("better-fetch", ...args),
-          log: (...args) => betterAuthLogger.info("better-fetch", ...args),
-          error: (...args) => betterAuthLogger.error("better-fetch", ...args),
-          warn: (...args) => betterAuthLogger.warn("better-fetch", ...args),
-        },
-      }),
-    ],
-  });
-}
-
 export function validateUrl(input: string): Result<URL, unknown> {
   try {
     const url = new URL(input);
@@ -99,4 +25,239 @@ export function validateUrl(input: string): Result<URL, unknown> {
   } catch (error) {
     return err(error);
   }
+}
+
+export function createRawFetch(args: FmOdataConfig) {
+  const result = validateUrl(args.serverUrl);
+
+  if (result.isErr()) {
+    throw new Error("Invalid server URL");
+  }
+
+  let baseURL = result.value.origin;
+  if ("apiKey" in args.auth) {
+    baseURL += `/otto`;
+  }
+  baseURL += `/fmi/odata/v4/${args.database}`;
+
+  // Create authentication headers
+  const authHeaders: Record<string, string> = {};
+  if ("apiKey" in args.auth) {
+    authHeaders.Authorization = `Bearer ${args.auth.apiKey}`;
+  } else {
+    const credentials = btoa(`${args.auth.username}:${args.auth.password}`);
+    authHeaders.Authorization = `Basic ${credentials}`;
+  }
+
+  // Enhanced fetch function with body handling, validation, and structured responses
+  const wrappedFetch = async <TOutput = any>(
+    input: string | URL | Request,
+    options?: Omit<RequestInit, "body"> & {
+      body?: any; // Allow any type for body
+      output?: z.ZodSchema<TOutput>; // Optional schema for validation
+    },
+  ): Promise<{ data?: TOutput; error?: string; response?: Response }> => {
+    try {
+      let url: string;
+
+      // Handle different input types
+      if (typeof input === "string") {
+        // If it's already a full URL, use as-is, otherwise prepend baseURL
+        url = input.startsWith("http")
+          ? input
+          : `${baseURL}${input.startsWith("/") ? input : `/${input}`}`;
+      } else if (input instanceof URL) {
+        url = input.toString();
+      } else if (input instanceof Request) {
+        url = input.url;
+      } else {
+        url = String(input);
+      }
+
+      // Handle body serialization
+      let processedBody = options?.body;
+      if (
+        processedBody &&
+        typeof processedBody === "object" &&
+        !(processedBody instanceof FormData) &&
+        !(processedBody instanceof URLSearchParams) &&
+        !(processedBody instanceof ReadableStream)
+      ) {
+        processedBody = JSON.stringify(processedBody);
+      }
+
+      // Merge headers
+      const headers = {
+        "Content-Type": "application/json",
+        ...authHeaders,
+        ...(options?.headers || {}),
+      };
+
+      const requestInit: RequestInit = {
+        ...options,
+        headers,
+        body: processedBody,
+      };
+
+      // Optional logging
+      if (args.logging === "verbose" || args.logging === true) {
+        betterAuthLogger.info(
+          "raw-fetch",
+          `${requestInit.method || "GET"} ${url}`,
+        );
+        if (requestInit.body) {
+          betterAuthLogger.info("raw-fetch", "Request body:", requestInit.body);
+        }
+      }
+
+      const response = await fetch(url, requestInit);
+
+      // Optional logging for response details
+      if (args.logging === "verbose" || args.logging === true) {
+        betterAuthLogger.info(
+          "raw-fetch",
+          `Response status: ${response.status} ${response.statusText}`,
+        );
+        betterAuthLogger.info(
+          "raw-fetch",
+          `Response headers:`,
+          Object.fromEntries(response.headers.entries()),
+        );
+      }
+
+      // Check if response is ok
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "Unknown error");
+        if (args.logging === "verbose" || args.logging === true) {
+          betterAuthLogger.error(
+            "raw-fetch",
+            `HTTP Error ${response.status}: ${errorText}`,
+          );
+        }
+        return {
+          error: `HTTP ${response.status}: ${errorText}`,
+          response,
+        };
+      }
+
+      // Parse response based on content type
+      let responseData: any;
+      const contentType = response.headers.get("content-type");
+
+      if (args.logging === "verbose" || args.logging === true) {
+        betterAuthLogger.info(
+          "raw-fetch",
+          `Response content-type: ${contentType || "none"}`,
+        );
+      }
+
+      if (contentType?.includes("application/json")) {
+        try {
+          const responseText = await response.text();
+          if (args.logging === "verbose" || args.logging === true) {
+            betterAuthLogger.info(
+              "raw-fetch",
+              `Raw response text: "${responseText}"`,
+            );
+            betterAuthLogger.info(
+              "raw-fetch",
+              `Response text length: ${responseText.length}`,
+            );
+          }
+
+          // Handle empty responses
+          if (responseText.trim() === "") {
+            if (args.logging === "verbose" || args.logging === true) {
+              betterAuthLogger.info(
+                "raw-fetch",
+                "Empty JSON response, returning null",
+              );
+            }
+            responseData = null;
+          } else {
+            responseData = JSON.parse(responseText);
+            if (args.logging === "verbose" || args.logging === true) {
+              betterAuthLogger.info(
+                "raw-fetch",
+                "Successfully parsed JSON response",
+              );
+            }
+          }
+        } catch (parseError) {
+          if (args.logging === "verbose" || args.logging === true) {
+            betterAuthLogger.error(
+              "raw-fetch",
+              "JSON parse error:",
+              parseError,
+            );
+          }
+          return {
+            error: `Failed to parse JSON response: ${parseError instanceof Error ? parseError.message : "Unknown parse error"}`,
+            response,
+          };
+        }
+      } else if (contentType?.includes("text/")) {
+        // Handle text responses (text/plain, text/html, etc.)
+        responseData = await response.text();
+        if (args.logging === "verbose" || args.logging === true) {
+          betterAuthLogger.info(
+            "raw-fetch",
+            `Text response: "${responseData}"`,
+          );
+        }
+      } else {
+        // For other content types, try to get text but don't fail if it's binary
+        try {
+          responseData = await response.text();
+          if (args.logging === "verbose" || args.logging === true) {
+            betterAuthLogger.info(
+              "raw-fetch",
+              `Unknown content-type response as text: "${responseData}"`,
+            );
+          }
+        } catch {
+          // If text parsing fails (e.g., binary data), return null
+          responseData = null;
+          if (args.logging === "verbose" || args.logging === true) {
+            betterAuthLogger.info(
+              "raw-fetch",
+              "Could not parse response as text, returning null",
+            );
+          }
+        }
+      }
+
+      // Validate output if schema provided
+      if (options?.output) {
+        const validation = options.output.safeParse(responseData);
+        if (validation.success) {
+          return {
+            data: validation.data,
+            response,
+          };
+        } else {
+          return {
+            error: `Validation failed: ${validation.error.message}`,
+            response,
+          };
+        }
+      }
+
+      // Return unvalidated data
+      return {
+        data: responseData as TOutput,
+        response,
+      };
+    } catch (error) {
+      return {
+        error:
+          error instanceof Error ? error.message : "Unknown error occurred",
+      };
+    }
+  };
+
+  return {
+    baseURL,
+    fetch: wrappedFetch,
+  };
 }

--- a/packages/better-auth/tests/adapter.test.ts
+++ b/packages/better-auth/tests/adapter.test.ts
@@ -57,6 +57,25 @@ describe("My Adapter Tests", async () => {
       return adapter(betterAuthOptions);
     },
   });
+
+  it("should sort descending", async () => {
+    const result = await adapter({}).findMany({
+      model: "verification",
+      where: [
+        {
+          field: "identifier",
+          operator: "eq",
+          value: "zyzaUHEsETWiuORCCdyguVVlVPcnduXk",
+        },
+      ],
+      limit: 1,
+      sortBy: { direction: "desc", field: "createdAt" },
+    });
+
+    console.log(result);
+
+    // expect(result.data).toHaveLength(1);
+  });
 });
 
 it("should properly filter by dates", async () => {
@@ -88,11 +107,21 @@ it("should properly filter by dates", async () => {
 
   console.log(result);
 
-  expect(result.data?.value).toHaveLength(1);
+  expect(result.data).toHaveLength(1);
 
   // delete record
   await fetch(`/user('filter-test')`, {
     method: "DELETE",
     throw: true,
+  });
+});
+
+it("should sort descending", async () => {
+  // delete all users
+  await fetch(`/user`, {
+    method: "DELETE",
+    query: {
+      $filter: `identifier eq 'zyzaUHEsETWiuORCCdyguVVlVPcnduXk'`,
+    },
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
 
   apps/demo:
     dependencies:
@@ -107,7 +107,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
 
   apps/docs:
     dependencies:
@@ -225,7 +225,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
 
   packages/better-auth:
     dependencies:
@@ -268,6 +268,9 @@ importers:
       neverthrow:
         specifier: ^8.2.0
         version: 8.2.0
+      odata-query:
+        specifier: ^8.0.4
+        version: 8.0.4
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -284,6 +287,9 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
+      '@vitest/ui':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4)
       fm-odata-client:
         specifier: ^3.0.1
         version: 3.0.1
@@ -295,7 +301,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
 
   packages/cli:
     dependencies:
@@ -434,7 +440,7 @@ importers:
         version: 7.7.0
       '@vitest/coverage-v8':
         specifier: ^1.4.0
-        version: 1.6.1(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0))
+        version: 1.6.1(vitest@3.2.4)
       drizzle-kit:
         specifier: ^0.21.4
         version: 0.21.4
@@ -482,7 +488,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
       zod:
         specifier: 3.25.64
         version: 3.25.64
@@ -561,7 +567,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
 
   packages/fmodata: {}
 
@@ -632,7 +638,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
 
   packages/webviewer:
     dependencies:
@@ -2436,6 +2442,9 @@ packages:
     resolution: {integrity: sha512-Tv4jcFUFAFjOWrGSio49H6R2ijALv0ZzVBfJKIdm+kl9X046Fh4LLawrF9OMsglVbK6ukqMJsUCeucGAFTBcMA==}
     engines: {node: '>=16'}
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@prisma/adapter-planetscale@5.22.0':
     resolution: {integrity: sha512-4fffELMJCAsvLaO4E4YKw6SsX8z3524f0th8dgagr4/p4PQwOJa8wQUktC3DXZdUGG0jyQUZF9ZYPM5e18UB+A==}
     peerDependencies:
@@ -3693,6 +3702,11 @@ packages:
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/ui@3.2.4':
+    resolution: {integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==}
+    peerDependencies:
+      vitest: 3.2.4
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -6389,6 +6403,10 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -6589,6 +6607,9 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  odata-query@8.0.4:
+    resolution: {integrity: sha512-v66MVxAZxlmOlFVaC9gvcDX5OcHO6yqc08AXhNhQ9LMbSzJKJ88uY1a7uDmLw2u4oMPGOMjnb8jdimA4kOD4Rw==}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -7371,6 +7392,10 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
+  sirv@3.0.1:
+    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -7695,6 +7720,10 @@ packages:
   token-types@6.0.0:
     resolution: {integrity: sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==}
     engines: {node: '>=14.16'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
@@ -9895,6 +9924,8 @@ snapshots:
 
   '@planetscale/database@1.19.0': {}
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@prisma/adapter-planetscale@5.22.0(@planetscale/database@1.19.0)':
     dependencies:
       '@planetscale/database': 1.19.0
@@ -11142,7 +11173,7 @@ snapshots:
     dependencies:
       crypto-js: 4.2.0
 
-  '@vitest/coverage-v8@1.6.1(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitest/coverage-v8@1.6.1(vitest@3.2.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -11157,7 +11188,7 @@ snapshots:
       std-env: 3.9.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11206,6 +11237,17 @@ snapshots:
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.3
+
+  '@vitest/ui@3.2.4(vitest@3.2.4)':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      fflate: 0.8.2
+      flatted: 3.3.3
+      pathe: 2.0.3
+      sirv: 3.0.1
+      tinyglobby: 0.2.14
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -12429,7 +12471,7 @@ snapshots:
       '@typescript-eslint/parser': 8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2)
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.27.0(jiti@2.4.2))
@@ -12449,7 +12491,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -12464,14 +12506,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2)
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -12486,7 +12528,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14536,6 +14578,8 @@ snapshots:
 
   mri@1.2.0: {}
 
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
 
   msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2):
@@ -14756,6 +14800,10 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  odata-query@8.0.4:
+    dependencies:
+      tslib: 2.8.1
 
   ohash@2.0.11: {}
 
@@ -15704,6 +15752,12 @@ snapshots:
       is-arrayish: 0.3.2
     optional: true
 
+  sirv@3.0.1:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   skin-tone@2.0.0:
@@ -16045,6 +16099,8 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  totalist@3.0.1: {}
 
   tough-cookie@4.1.4:
     dependencies:
@@ -16475,7 +16531,7 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.8.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@1.21.7)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -16503,6 +16559,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.17.1
+      '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 15.11.7
     transitivePeerDependencies:
       - jiti
@@ -16518,7 +16575,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.17.1)(@vitest/ui@3.2.4)(happy-dom@15.11.7)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.2(@types/node@22.17.1)(typescript@5.9.2))(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -16546,6 +16603,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.17.1
+      '@vitest/ui': 3.2.4(vitest@3.2.4)
       happy-dom: 15.11.7
     transitivePeerDependencies:
       - jiti

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,12 +235,6 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.27.1
         version: 7.27.1(@babel/core@7.27.7)
-      '@better-fetch/fetch':
-        specifier: 1.1.17
-        version: 1.1.17
-      '@better-fetch/logger':
-        specifier: ^1.1.18
-        version: 1.1.18
       '@commander-js/extra-typings':
         specifier: ^14.0.0
         version: 14.0.0(commander@14.0.0)
@@ -930,9 +924,6 @@ packages:
 
   '@better-fetch/fetch@1.1.18':
     resolution: {integrity: sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA==}
-
-  '@better-fetch/logger@1.1.18':
-    resolution: {integrity: sha512-jiBJefQhU1tCzG5HQ+Qez0/Kn5qKO4t5e1cocdNBPRXrzKHPqwW8TbD9p4u0iKYVG3knT5GR8R8DdesVJdiLSQ==}
 
   '@braidai/lang@1.1.1':
     resolution: {integrity: sha512-5uM+no3i3DafVgkoW7ayPhEGHNNBZCSj5TrGDQt0ayEKQda5f3lAXlmQg0MR5E0gKgmTzUUEtSWHsEC3h9jUcg==}
@@ -8673,10 +8664,6 @@ snapshots:
 
   '@better-fetch/fetch@1.1.18': {}
 
-  '@better-fetch/logger@1.1.18':
-    dependencies:
-      consola: 3.4.2
-
   '@braidai/lang@1.1.1': {}
 
   '@bundled-es-modules/cookie@2.0.1':
@@ -12471,7 +12458,7 @@ snapshots:
       '@typescript-eslint/parser': 8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2)
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.27.0(jiti@2.4.2))
@@ -12491,7 +12478,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -12506,14 +12493,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2)
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -12528,7 +12515,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2)))(eslint@9.27.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.33.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.27.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
add order by test

Update pnpm-lock.yaml and package.json for better-auth package; integrate odata-query and @vitest/ui dependencies, refactor fetch logic in adapter and migrate files for improved error handling and query construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * New flexible fetch wrapper with optional verbose logging.
  * Adapter queries now use URL query parameters for find/count, support sorting (including descending), and a config option to toggle pluralized model names.

* Refactor
  * Switched to a raw REST-style fetch approach and updated migration flows with improved error handling and response validation.

* Chores
  * Updated dependencies (added OData query builder, test UI; removed unused packages).

* Tests
  * Expanded tests for migrations, filtering, sorting, and safer cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->