### PR TITLE
Changesets version push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
+  # Changesets/action needs to push version commits and open/update a PR
+  contents: write
+  pull-requests: write
   id-token: write # Required for OIDC
 
 jobs:
@@ -38,5 +41,5 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}


### PR DESCRIPTION
Grant `contents: write` and `pull-requests: write` permissions to `GITHUB_TOKEN` in `release.yml` to fix Changesets action push failures.

The previous workflow explicitly restricted `GITHUB_TOKEN` permissions to `id-token: write` only, causing a 403 error when the Changesets action attempted to push version updates and manage the release PR. This change provides the necessary write access for `contents` and `pull-requests`, and updates `secrets.GITHUB_TOKEN` to `github.token` for standard usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-7005a8af-5f0e-42bf-ae1a-00623c521965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7005a8af-5f0e-42bf-ae1a-00623c521965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Changesets action can push version commits and manage the release PR.
> 
> - Adds `contents: write` and `pull-requests: write` in `permissions` of `release.yml`
> - Switches `GITHUB_TOKEN` from `secrets.GITHUB_TOKEN` to `${{ github.token }}` in the Changesets step
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8b919fe1f2c2f382aebcb0cc6f7ff6c2f792f3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->