### PR TITLE
only run post-generate command once

### DIFF
--- a/.changeset/bright-dogs-teach.md
+++ b/.changeset/bright-dogs-teach.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/typegen": patch
+---
+
+Fix post-generate command to run once after all configs instead of once per config. 

--- a/packages/typegen/src/fmodata/generateODataTypes.ts
+++ b/packages/typegen/src/fmodata/generateODataTypes.ts
@@ -878,7 +878,6 @@ export async function generateODataTypes(
   metadata: ParsedMetadata,
   config: FmodataConfig & {
     alwaysOverrideFieldNames?: boolean;
-    postGenerateCommand?: string;
     cwd?: string;
   },
 ): Promise<void> {
@@ -889,7 +888,6 @@ export async function generateODataTypes(
     tables,
     alwaysOverrideFieldNames = true,
     includeAllFieldsByDefault = true,
-    postGenerateCommand,
     cwd = process.cwd(),
   } = config;
   const outputPath = path ?? "schema";
@@ -1314,6 +1312,6 @@ ${exportStatements.join("\n")}
     overwrite: true,
   });
 
-  // Format and save files, then run post-generate command if provided
-  await formatAndSaveSourceFiles(project, postGenerateCommand, cwd);
+  // Format and save files
+  await formatAndSaveSourceFiles(project, cwd);
 }

--- a/packages/typegen/src/fmodata/typegen.ts
+++ b/packages/typegen/src/fmodata/typegen.ts
@@ -60,7 +60,7 @@ export async function generateODataTablesSingle(
   };
 
   // Generate types from merged metadata
-  await generateODataTypes(mergedMetadata, { ...config, postGenerateCommand: options?.postGenerateCommand, cwd });
+  await generateODataTypes(mergedMetadata, { ...config, cwd });
 
   // Return the resolved output path
   return path.resolve(cwd, outputPath);

--- a/packages/typegen/src/formatting.ts
+++ b/packages/typegen/src/formatting.ts
@@ -6,14 +6,9 @@ import type { Project } from "ts-morph";
 /**
  * Formats all source files in a ts-morph Project using prettier and saves the changes.
  * @param project The ts-morph Project containing the files to format
- * @param postGenerateCommand Optional command to run after formatting
  * @param cwd Current working directory for command execution
  */
-export async function formatAndSaveSourceFiles(
-  project: Project,
-  postGenerateCommand?: string,
-  cwd: string = process.cwd(),
-) {
+export async function formatAndSaveSourceFiles(project: Project, _cwd: string = process.cwd()) {
   try {
     const files = project.getSourceFiles();
 
@@ -30,7 +25,14 @@ export async function formatAndSaveSourceFiles(
     // Ignore formatting errors and continue
   }
   await project.save();
+}
 
+/**
+ * Runs the post-generate command if provided.
+ * @param postGenerateCommand Optional command to run after formatting
+ * @param cwd Current working directory for command execution
+ */
+export async function runPostGenerateCommand(postGenerateCommand?: string, cwd: string = process.cwd()) {
   if (postGenerateCommand) {
     try {
       // Parse the command string into command and arguments


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes post-generate execution and removes per-config invocations.
> 
> - Adds `runPostGenerateCommand` and calls it once at the end of `generateTypedClients` (after all configs)
> - Removes `postGenerateCommand` plumbing from `fmodata` generators and `formatAndSaveSourceFiles`; formatting now only formats/saves
> - Updates `generateODataTypes`/`generateODataTablesSingle` and `generateTypedClientsSingle` to drop per-config command execution
> - Changeset: patch release for `@proofkit/typegen`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9e8b23611e50dd4bf140194c8e6499783894d0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->