### PR TITLE
ci: remove E2E tests from CI workflow

### DIFF
--- a/.github/workflows/continuous-release.yml
+++ b/.github/workflows/continuous-release.yml
@@ -54,9 +54,6 @@ jobs:
     if: github.ref != 'refs/heads/beads-sync'
     runs-on: ubuntu-latest
     needs: [lint, typecheck]
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -70,26 +67,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v3
-
-      - name: Get OIDC token
-        run: |
-          TOKEN=$(curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://github.com/$GITHUB_REPOSITORY_OWNER")
-          echo "OIDC_TOKEN=$(echo $TOKEN | jq -r '.value')" >> $GITHUB_ENV
-
-      - name: Authenticate with Doppler
-        run: |
-          doppler oidc login --scope=. --identity=${{ vars.DOPPLER_SERVICE_IDENTITY_ID }} --token=$OIDC_TOKEN
-          doppler configure set project proofkit
-          doppler configure set config test
-
       - name: Run Unit Tests
         run: pnpm test
-
-      - name: Run fmodata E2E Tests
-        run: pnpm --filter @proofkit/fmodata test:e2e
 
   build:
     if: github.ref != 'refs/heads/beads-sync'

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "sherif:fix": "pnpm sherif --fix",
     "release": "turbo run build --filter={./packages/*} && changeset publish",
     "test": "turbo run test",
+    "test:e2e": "turbo run test:e2e",
     "knip": "knip",
     "prepare": "husky"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,19 @@
       "outputs": [],
       "dependsOn": ["^build"]
     },
+    "test:e2e": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "vitest.config.*",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx"
+      ],
+      "outputs": [],
+      "dependsOn": ["^build"],
+      "cache": false
+    },
     "test:watch": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Remove fmodata E2E step and Doppler auth from continuous-release.yml.
Add root-level test:e2e script and turbo task for local E2E runs.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines CI and enables local E2E runs.
> 
> - Removes Doppler OIDC auth and `@proofkit/fmodata` E2E step from `continuous-release.yml`; CI now runs lint, typecheck, unit tests, and build only
> - Adds root-level `test:e2e` script and a non-cached `test:e2e` turbo task for local E2E execution
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1d12145160e2fbf3813b21bc3527962f921bcc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->