### PR TITLE
fix(fmodata): navigate() includes parent table when defaultSelect is schema

### DIFF
--- a/.changeset/fix-navigate-defaultselect-schema.md
+++ b/.changeset/fix-navigate-defaultselect-schema.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/fmodata": patch
+---
+
+Fix navigate() not including parent table in URL when defaultSelect is "schema" or object (#107)

--- a/packages/fmodata/src/client/entity-set.ts
+++ b/packages/fmodata/src/client/entity-set.ts
@@ -120,7 +120,17 @@ export class EntitySet<Occ extends FMTable<any, any>, DatabaseIncludeSpecialColu
         // Include special columns if enabled at database level
         const systemColumns = this.databaseIncludeSpecialColumns ? { ROWID: true, ROWMODID: true } : undefined;
 
-        return builder.select(allColumns, systemColumns).top(1000) as QueryBuilder<
+        const selectedBuilder = builder.select(allColumns, systemColumns).top(1000);
+        // Propagate navigation context if present
+        if (this.isNavigateFromEntitySet && this.navigateRelation && this.navigateSourceTableName) {
+          // biome-ignore lint/suspicious/noExplicitAny: Mutation of readonly properties for builder pattern
+          (selectedBuilder as any).navigation = {
+            relation: this.navigateRelation,
+            sourceTableName: this.navigateSourceTableName,
+            basePath: this.navigateBasePath,
+          };
+        }
+        return selectedBuilder as QueryBuilder<
           Occ,
           keyof InferSchemaOutputFromFMTable<Occ>,
           false,
@@ -134,7 +144,17 @@ export class EntitySet<Occ extends FMTable<any, any>, DatabaseIncludeSpecialColu
       if (typeof defaultSelectValue === "object") {
         // defaultSelectValue is a select object (Record<string, Column>)
         // Cast to the declared return type - runtime behavior handles the actual selection
-        return builder.select(defaultSelectValue as ExtractColumnsFromOcc<Occ>).top(1000) as QueryBuilder<
+        const selectedBuilder = builder.select(defaultSelectValue as ExtractColumnsFromOcc<Occ>).top(1000);
+        // Propagate navigation context if present
+        if (this.isNavigateFromEntitySet && this.navigateRelation && this.navigateSourceTableName) {
+          // biome-ignore lint/suspicious/noExplicitAny: Mutation of readonly properties for builder pattern
+          (selectedBuilder as any).navigation = {
+            relation: this.navigateRelation,
+            sourceTableName: this.navigateSourceTableName,
+            basePath: this.navigateBasePath,
+          };
+        }
+        return selectedBuilder as QueryBuilder<
           Occ,
           keyof InferSchemaOutputFromFMTable<Occ>,
           false,


### PR DESCRIPTION
Fix #107: navigation context wasn't propagated when defaultSelect was
"schema" or object because list() returned early before reaching the
navigation propagation code.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes missing navigation context when listing from a navigated `EntitySet` with `defaultSelect` set to `"schema"` or a select object.
> 
> - Updates `entity-set.ts`: after applying default selects, propagate `navigation` metadata onto the selected `QueryBuilder` so URLs include the parent path (e.g., `/contacts/users`), and keep default `top(1000)` behavior
> - Adds tests in `navigate.test.ts` for issue #107 covering `defaultSelect='schema'` navigation path inclusion with and without filters
> - Minor cleanup in `scripts/test-crossjoin.ts`: stricter env checks, trailing slash handling, and logging tweaks
> - Adds a changeset entry for `@proofkit/fmodata` patch release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3469d5920c379d448e966c4da443303f3ebe0d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->