### PR TITLE
fix(typegen): convert list-tables endpoint from GET to POST

### DIFF
--- a/.changeset/list-tables-post.md
+++ b/.changeset/list-tables-post.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/typegen": patch
+---
+
+Fix list-tables endpoint 431 error by converting from GET to POST

--- a/packages/typegen/web/src/hooks/useListTables.ts
+++ b/packages/typegen/web/src/hooks/useListTables.ts
@@ -24,9 +24,9 @@ export function useListTables(configIndex: number, enabled?: boolean) {
         throw new Error("Config not found or invalid type");
       }
 
-      const res = await client.api["list-tables"].$get({
-        query: {
-          config: JSON.stringify(config),
+      const res = await client.api["list-tables"].$post({
+        json: {
+          config,
         },
       });
 


### PR DESCRIPTION
Prevents 431 Request Header Fields Too Large when config grows.
Passes config as JSON body instead of query param, matching
test-connection and table-metadata endpoints.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `list-tables` API contract from querystring GET to JSON-body POST, which can break any external callers not updated. Logic is otherwise unchanged and scoped to this single endpoint + its web client hook.
> 
> **Overview**
> Prevents `431 Request Header Fields Too Large` by **changing `list-tables` from `GET /api/list-tables?config=...` to `POST /api/list-tables` with `{ config }` in the JSON body**, aligning it with other endpoints.
> 
> Updates the web `useListTables` hook to call the new POST endpoint, and adds a patch changeset for `@proofkit/typegen` documenting the behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 214a1b5909b7bf232a969c43e12268e102c1d1cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->