### PR TITLE
feat(fmodata): add OData string functions matchesPattern, tolower, toupper, trim

### DIFF
--- a/.changeset/odata-string-functions.md
+++ b/.changeset/odata-string-functions.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/fmodata": minor
+---
+
+Add OData string functions: `matchesPattern`, `tolower`, `toupper`, `trim`

--- a/apps/docs/content/docs/fmodata/methods.mdx
+++ b/apps/docs/content/docs/fmodata/methods.mdx
@@ -58,6 +58,7 @@ Quick reference for all available methods and operators in `@proofkit/fmodata`.
 | `contains(column, value)` | Contains substring | `contains(users.name, "John")` |
 | `startsWith(column, value)` | Starts with | `startsWith(users.email, "admin")` |
 | `endsWith(column, value)` | Ends with | `endsWith(users.email, ".com")` |
+| `matchesPattern(column, pattern)` | Matches regex pattern | `matchesPattern(users.name, "^A.*e$")` |
 
 ### Array Operators
 
@@ -80,6 +81,25 @@ Quick reference for all available methods and operators in `@proofkit/fmodata`.
 | `and(...filters)` | Logical AND | `and(eq(users.active, true), gt(users.age, 18))` |
 | `or(...filters)` | Logical OR | `or(eq(users.role, "admin"), eq(users.role, "moderator"))` |
 | `not(filter)` | Logical NOT | `not(eq(users.active, false))` |
+
+### String Transform Functions
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `tolower(column)` | Convert to lowercase | `eq(tolower(users.name), "john")` |
+| `toupper(column)` | Convert to uppercase | `eq(toupper(users.name), "JOHN")` |
+| `trim(column)` | Remove leading/trailing whitespace | `eq(trim(users.name), "John")` |
+
+String transforms can be nested and used with any operator:
+
+```typescript
+// Nested transforms
+eq(tolower(trim(users.name)), "john")
+
+// With other operators
+contains(tolower(users.name), "john")
+startsWith(toupper(users.email), "ADMIN")
+```
 
 ## Sort Helpers
 

--- a/apps/docs/content/docs/fmodata/queries.mdx
+++ b/apps/docs/content/docs/fmodata/queries.mdx
@@ -97,6 +97,7 @@ const result = await db
 - `contains()` - Contains substring
 - `startsWith()` - Starts with
 - `endsWith()` - Ends with
+- `matchesPattern()` - Matches regex pattern
 
 **Array:**
 - `inArray()` - Value in array
@@ -110,6 +111,11 @@ const result = await db
 - `and()` - Logical AND
 - `or()` - Logical OR
 - `not()` - Logical NOT
+
+**String Transforms:**
+- `tolower()` - Convert to lowercase for comparison
+- `toupper()` - Convert to uppercase for comparison
+- `trim()` - Remove leading/trailing whitespace
 
 ## Sorting
 

--- a/packages/fmodata/src/index.ts
+++ b/packages/fmodata/src/index.ts
@@ -61,6 +61,7 @@ export {
   asc,
   // Column references
   type Column,
+  type ColumnFunction,
   calcField,
   containerField,
   contains,
@@ -88,10 +89,12 @@ export {
   type InferTableSchema,
   inArray,
   isColumn,
+  isColumnFunction,
   isNotNull,
   isNull,
   lt,
   lte,
+  matchesPattern,
   ne,
   not,
   notInArray,
@@ -104,6 +107,9 @@ export {
   textField,
   timeField,
   timestampField,
+  tolower,
+  toupper,
+  trim,
 } from "./orm/index";
 // Utility types for type annotations
 export type {

--- a/packages/fmodata/src/orm/index.ts
+++ b/packages/fmodata/src/orm/index.ts
@@ -2,7 +2,7 @@
 // Field builders - main API for defining table schemas
 
 // Column references - used in queries and filters
-export { Column, isColumn } from "./column";
+export { Column, ColumnFunction, isColumn, isColumnFunction } from "./column";
 export {
   type ContainerDbType,
   calcField,
@@ -32,6 +32,7 @@ export {
   isOrderByExpression,
   lt,
   lte,
+  matchesPattern,
   ne,
   not,
   notInArray,
@@ -39,6 +40,9 @@ export {
   OrderByExpression,
   or,
   startsWith,
+  tolower,
+  toupper,
+  trim,
 } from "./operators";
 
 // Table definition - fmTableOccurrence function

--- a/skills/proofkit-fmodata/references/fmodata-api.md
+++ b/skills/proofkit-fmodata/references/fmodata-api.md
@@ -164,11 +164,32 @@ import { eq, ne, gt, gte, lt, lte } from "@proofkit/fmodata";
 ### String
 
 ```typescript
-import { contains, startsWith, endsWith } from "@proofkit/fmodata";
+import { contains, startsWith, endsWith, matchesPattern } from "@proofkit/fmodata";
 
 .where(contains(Users.email, "@example.com"))
 .where(startsWith(Users.name, "John"))
 .where(endsWith(Users.email, ".com"))
+.where(matchesPattern(Users.name, "^A.*e$"))
+```
+
+### String Transforms
+
+```typescript
+import { tolower, toupper, trim } from "@proofkit/fmodata";
+
+// Case-insensitive comparison
+.where(eq(tolower(Users.name), "john"))
+.where(eq(toupper(Users.name), "JOHN"))
+
+// Trim whitespace
+.where(eq(trim(Users.name), "John"))
+
+// Nest transforms
+.where(eq(tolower(trim(Users.name)), "john"))
+
+// Use with any operator
+.where(contains(tolower(Users.name), "john"))
+.where(startsWith(toupper(Users.email), "ADMIN"))
 ```
 
 ### Array


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core filter serialization by adding a new `Column` subtype and operand-handling logic, which could subtly affect query-string generation. Changes are additive and covered by new unit tests, keeping risk contained.
> 
> **Overview**
> Adds new OData filter capabilities to `@proofkit/fmodata`: a `matchesPattern(column, pattern)` string operator and nestable string transform helpers `tolower`, `toupper`, and `trim` that can wrap columns and be used with existing operators (e.g., `eq(tolower(col), 'x')`).
> 
> Implements a new `ColumnFunction` wrapper (plus `isColumnFunction`) to serialize transforms, including correct field quoting and support for entity IDs, and wires these new exports through the public API. Updates docs/reference material and extends filter/ORM tests to cover the new operator, nested transforms, quoting behavior, and entity-id serialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec08889669ce36e0a902c9f2a68239dd3c732a44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->