### PR TITLE
fix(fmodata): preserve useEntityIds through navigate()

### DIFF
--- a/.changeset/fix-navigate-useentityids.md
+++ b/.changeset/fix-navigate-useentityids.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/fmodata": patch
+---
+
+Fix navigate() losing per-table useEntityIds after Database.from() mutation fix

--- a/packages/fmodata/src/client/record-builder.ts
+++ b/packages/fmodata/src/client/record-builder.ts
@@ -445,9 +445,8 @@ export class RecordBuilder<
       databaseIncludeSpecialColumns: this.databaseIncludeSpecialColumns,
     });
 
-    // Store the navigation info - we'll use it in execute
-    // Use relation name as-is (entity ID handling is done in QueryBuilder)
-    const relationId = relationName;
+    // Store the navigation info - resolve entity ID for relation if needed
+    const relationId = resolveTableId(targetTable, relationName, this.context, this.databaseUseEntityIds);
 
     // If this RecordBuilder came from a navigated EntitySet, we need to preserve that base path
     let sourceTableName: string;


### PR DESCRIPTION
navigate() lost per-table useEntityIds after Database.from() mutation
fix. Now passes resolved useEntityIds to new EntitySet and resolves
navigation path names through resolveTableId for entity ID support.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized URL/path construction changes with added test coverage; main risk is subtle regressions in navigation path formatting for entity-ID vs name-based routing.
> 
> **Overview**
> Fixes `navigate()` so entity-ID mode is preserved across navigation chains.
> 
> `EntitySet.navigate()` now forwards `useEntityIds` into the newly-created `EntitySet` and resolves both the source table name and relation name via `resolveTableId`; `RecordBuilder.navigate()` similarly resolves the relation identifier via `resolveTableId`. Tests add coverage ensuring generated navigation paths use `FMTID:*` identifiers (and not table names) for both EntitySet- and record-based navigation when per-table `useEntityIds` is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5dfb43b1bb1612151b3a1c65e1154e7f2e934cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->