### PR TITLE
fix(typegen): preserve fmodata customizations with clearOldFiles

### DIFF
--- a/.changeset/fix-fmodata-clearoldfiles-preserve-customizations.md
+++ b/.changeset/fix-fmodata-clearoldfiles-preserve-customizations.md
@@ -1,0 +1,7 @@
+---
+"@proofkit/typegen": patch
+---
+
+Fix fmodata type generation to preserve existing field-level customizations even when `clearOldFiles` is enabled.
+
+Stale files in the output directory are now removed after regeneration, so dead generated files are still cleaned up without discarding validator customizations from existing schemas.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `clearOldFiles` behavior to delete files *after* regeneration via a recursive cleanup, which could remove unexpected entries if the output path is misconfigured, but is otherwise localized to type generation output.
> 
> **Overview**
> Fixes `fmodata` type generation so `clearOldFiles` no longer nukes the output directory before merging with existing files; existing schemas are now always parsed so field-level customizations (e.g. validators) are preserved.
> 
> When `clearOldFiles` is enabled, stale files/directories are now removed *after* generation by tracking regenerated files (including `index.ts`) and deleting any other entries in the output tree. Adds an e2e test covering customization preservation plus stale file cleanup, and includes a patch changeset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea7f4c23611061e2ac8385ea68bd48cb528b3975. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->