### PR TITLE
Add back notify-intent workflow for trigger skill review

### DIFF
--- a/.github/workflows/notify-intent.yml
+++ b/.github/workflows/notify-intent.yml
@@ -17,7 +17,8 @@ name: Trigger Skill Review
 on:
   push:
     branches: [main]
-    paths:      - 'packages/better-auth/docs/**'
+    paths:
+      - 'packages/better-auth/docs/**'
       - 'packages/better-auth/src/**'
       - 'packages/fmdapi/docs/**'
       - 'packages/fmdapi/src/**'


### PR DESCRIPTION
Restored via `npx @tanstack/intent setup-github-actions`, which now
correctly uses ${{ github.repository }} instead of the previously
hardcoded TanStack/intent reference (TanStack/intent#76).

https://claude.ai/code/session_01BfPVaoi6ZYhToyK1YA9EP4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to trigger skill review validation on pushes to main when package files change; it collects the changed files and notifies the review process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->