### PR TITLE
fix(typegen): fields dialog overflow in bottom settings bar

### DIFF
--- a/.changeset/fix-typegen-fields-dialog-overflow.md
+++ b/.changeset/fix-typegen-fields-dialog-overflow.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/typegen": patch
+---
+
+Fix overflow in metadata fields dialog where bottom settings form overlapped with data grid

--- a/packages/typegen/web/src/components/metadata-fields-dialog/FieldsDataGrid.tsx
+++ b/packages/typegen/web/src/components/metadata-fields-dialog/FieldsDataGrid.tsx
@@ -73,14 +73,13 @@ export function FieldsDataGrid({ table, isLoading, isError, error, open }: Field
       table={table}
       tableLayout={{ width: "auto", headerSticky: true }}
     >
-      <DataGridContainer border={true}>
+      <DataGridContainer border={true} className="h-full">
         <div
           className="overflow-auto"
           ref={tableContainerRef}
           style={{
             contain: "strict",
-            height: "650px",
-            maxHeight: "650px",
+            height: "100%",
           }}
         >
           <table className="w-full border-separate border-spacing-0">

--- a/packages/typegen/web/src/components/metadata-fields-dialog/MetadataFieldsDialog.tsx
+++ b/packages/typegen/web/src/components/metadata-fields-dialog/MetadataFieldsDialog.tsx
@@ -157,7 +157,7 @@ export function MetadataFieldsDialog({ open, onOpenChange, tableName, configInde
             Including {selectedFieldsCount} of {fieldsData.length} fields for {tableName || "Table"}
           </DialogTitle>
         </DialogHeader>
-        <DialogBody className="flex min-h-0 flex-1 flex-col overflow-x-auto overflow-y-auto">
+        <DialogBody className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <div className="mb-2 shrink-0 space-y-2">
             <InputWrapper>
               <Search className="size-4" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overflow issue in the metadata fields dialog where the bottom settings form overlapped with the data grid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->