### PR TITLE
fix(fmdapi): align repository URL for npm provenance

### DIFF
--- a/packages/fmdapi/package.json
+++ b/packages/fmdapi/package.json
@@ -2,7 +2,10 @@
   "name": "@proofkit/fmdapi",
   "version": "5.1.0-beta.2",
   "description": "FileMaker Data API client",
-  "repository": "git@github.com:proofgeist/fm-dapi.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/proofgeist/proofkit"
+  },
   "author": "Eric <37158449+eluce2@users.noreply.github.com>",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary
- update `packages/fmdapi/package.json` repository URL to point to `proofgeist/proofkit`
- aligns package metadata with GitHub Actions provenance source used during release

## Why
Recent release run failed publishing `@proofkit/fmdapi` with npm provenance validation error (E422) due to repository mismatch.

## Validation
- metadata-only change
- no runtime code changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository metadata configuration to use structured object format with type and URL fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->