### PR TITLE
fix(typegen): restore field rows visibility in metadata fields dialog

### DIFF
--- a/packages/typegen/web/src/components/metadata-fields-dialog/FieldsDataGrid.tsx
+++ b/packages/typegen/web/src/components/metadata-fields-dialog/FieldsDataGrid.tsx
@@ -73,13 +73,13 @@ export function FieldsDataGrid({ table, isLoading, isError, error, open }: Field
       table={table}
       tableLayout={{ width: "auto", headerSticky: true }}
     >
-      <DataGridContainer border={true} className="h-full">
+      <DataGridContainer border={true}>
         <div
           className="overflow-auto"
           ref={tableContainerRef}
           style={{
             contain: "strict",
-            height: "100%",
+            height: "calc(90vh - 280px)", // Adjust based on dialog header and search input height
           }}
         >
           <table className="w-full border-separate border-spacing-0">

--- a/packages/typegen/web/src/components/metadata-fields-dialog/TableOptionsForm.tsx
+++ b/packages/typegen/web/src/components/metadata-fields-dialog/TableOptionsForm.tsx
@@ -48,7 +48,7 @@ export function TableOptionsForm({
   const isDisabled = currentTableIndex < 0 || configType !== "fmodata" || !open;
 
   return (
-    <div className="shrink-0 border-border border-t pt-4">
+    <div className="shrink-0 pt-3">
       <div className="flex gap-4">
         <FormField
           control={control}


### PR DESCRIPTION
## Summary
- Fixed field rows not displaying in the metadata fields dialog (regression from 8ca7a1e)
- The previous overflow fix changed scroll container height from `650px` to `100%`, but `contain: strict` requires an explicit resolved height — `height: 100%` couldn't resolve through the CSS grid parent chain, collapsing the container to 0px
- Uses viewport-based `calc(90vh - 280px)` height instead, derived from the dialog's `max-h-[90vh]` minus header/search/settings
- Removed `border-t` on the settings form that visually collided with the data grid's bottom border

## Test plan
- [ ] Open the typegen web UI and click "Configure" on any table
- [ ] Verify field rows are visible in the dialog
- [ ] Verify the settings form below the table has no double-border artifact
- [ ] Verify scrolling works correctly with many fields
- [ ] Test on different viewport sizes to ensure the calc-based height is reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted data grid container height calculation for improved scrolling behavior
  * Modified form styling with updated spacing and visual elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->