### PR TITLE
Fix fmodata invalid entity-id query error handling

### DIFF
--- a/.changeset/fix-invalid-entity-id-errors.md
+++ b/.changeset/fix-invalid-entity-id-errors.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/fmodata": patch
+---
+
+Return structured query errors for invalid entity-id table refs and unresolved filter operands instead of throwing or sending malformed OData filters

--- a/packages/fmodata/src/client/query/query-builder.ts
+++ b/packages/fmodata/src/client/query/query-builder.ts
@@ -3,7 +3,8 @@ import type { FFetchOptions } from "@fetchkit/ffetch";
 import { Effect } from "effect";
 import buildQuery, { type QueryOptions } from "odata-query";
 import { requestFromService, runLayerResult } from "../../effect";
-import { RecordCountMismatchError } from "../../errors";
+import type { FMODataErrorType } from "../../errors";
+import { BuilderInvariantError, isFMODataError, RecordCountMismatchError } from "../../errors";
 import type { InternalLogger } from "../../logger";
 import { type Column, isColumn } from "../../orm/column";
 import { type FilterExpression, isOrderByExpression, type OrderByExpression } from "../../orm/operators";
@@ -53,6 +54,16 @@ export type { QueryReturnType, SystemColumnsOption, TypeSafeOrderBy } from "./ty
  * allowing substantial data retrieval. Users can override with .top().
  */
 const _DEFAULT_TOP = 1000;
+
+function normalizeQueryBuildError(error: unknown): FMODataErrorType {
+  if (isFMODataError(error)) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new BuilderInvariantError("QueryBuilder.execute", error.message, { cause: error });
+  }
+  return new BuilderInvariantError("QueryBuilder.execute", String(error));
+}
 
 export class QueryBuilder<
   // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration
@@ -682,15 +693,31 @@ export class QueryBuilder<
     >;
 
     const mergedOptions = this.mergeExecuteOptions(options);
-    const queryString = this.buildQueryString(mergedOptions.includeSpecialColumns, mergedOptions.useEntityIds);
+    let queryString: string;
+    try {
+      queryString = this.buildQueryString(mergedOptions.includeSpecialColumns, mergedOptions.useEntityIds);
+    } catch (error) {
+      return Promise.resolve({
+        data: undefined,
+        error: normalizeQueryBuildError(error),
+      }) as Promise<Result<ExecuteResponse>>;
+    }
 
     // Handle $count endpoint
     if (this.readState.isCountMode) {
-      const url = this.urlBuilder.build(queryString, {
-        isCount: true,
-        useEntityIds: mergedOptions.useEntityIds,
-        navigation: this.readState.navigation,
-      });
+      let url: string;
+      try {
+        url = this.urlBuilder.build(queryString, {
+          isCount: true,
+          useEntityIds: mergedOptions.useEntityIds,
+          navigation: this.readState.navigation,
+        });
+      } catch (error) {
+        return Promise.resolve({
+          data: undefined,
+          error: normalizeQueryBuildError(error),
+        }) as Promise<Result<ExecuteResponse>>;
+      }
 
       const pipeline = requestFromService(url, mergedOptions).pipe(
         Effect.map((data) => {
@@ -704,11 +731,19 @@ export class QueryBuilder<
       }) as Promise<Result<ExecuteResponse>>;
     }
 
-    const url = this.urlBuilder.build(queryString, {
-      isCount: this.readState.isCountMode,
-      useEntityIds: mergedOptions.useEntityIds,
-      navigation: this.readState.navigation,
-    });
+    let url: string;
+    try {
+      url = this.urlBuilder.build(queryString, {
+        isCount: this.readState.isCountMode,
+        useEntityIds: mergedOptions.useEntityIds,
+        navigation: this.readState.navigation,
+      });
+    } catch (error) {
+      return Promise.resolve({
+        data: undefined,
+        error: normalizeQueryBuildError(error),
+      }) as Promise<Result<ExecuteResponse>>;
+    }
 
     const pipeline = requestFromService(url, mergedOptions).pipe(
       Effect.flatMap((data) =>

--- a/packages/fmodata/src/orm/operators.ts
+++ b/packages/fmodata/src/orm/operators.ts
@@ -216,6 +216,12 @@ export class FilterExpression {
     if (value instanceof Date) {
       return value.toISOString();
     }
+    if (typeof value === "object") {
+      const valueType = value?.constructor?.name ?? "Object";
+      throw new Error(
+        `Unsupported filter operand: received ${valueType}. Pass a table column or a primitive filter value.`,
+      );
+    }
     return String(value);
   }
 }

--- a/packages/fmodata/tests/entity-id-invalid-reference.test.ts
+++ b/packages/fmodata/tests/entity-id-invalid-reference.test.ts
@@ -1,0 +1,60 @@
+import { eq, fmTableOccurrence, textField } from "@proofkit/fmodata";
+import { MockFMServerConnection } from "@proofkit/fmodata/testing";
+import { describe, expect, it } from "vitest";
+
+const contacts = fmTableOccurrence(
+  "contacts",
+  {
+    id: textField().primaryKey().entityId("FMFID:1"),
+    name: textField().entityId("FMFID:2"),
+  },
+  {
+    entityId: "FMTID:100",
+  },
+);
+
+describe("invalid entity-id references", () => {
+  it("returns an error result when useEntityIds is enabled for a table without entity IDs", async () => {
+    const fakeTable = fmTableOccurrence("NonExistent", {
+      id: textField().primaryKey().entityId("FMFID:999999999"),
+    });
+
+    const mock = new MockFMServerConnection({ enableSpy: true });
+    mock.addRoute({
+      urlPattern: "/TestDB",
+      response: { value: [] },
+      status: 200,
+    });
+
+    const db = mock.database("TestDB", { useEntityIds: true });
+    const result = await db.from(fakeTable).list().execute();
+
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toContain('table "NonExistent"');
+    expect(mock.spy?.calls).toHaveLength(0);
+  });
+
+  it("returns an error result for unresolved field-like operands in filters", async () => {
+    const looseField = textField().entityId("FMFID:000000001");
+
+    const mock = new MockFMServerConnection({ enableSpy: true });
+    mock.addRoute({
+      urlPattern: "/TestDB",
+      response: { value: [] },
+      status: 200,
+    });
+
+    const db = mock.database("TestDB", { useEntityIds: true });
+    const result = await db
+      .from(contacts)
+      .list()
+      .where(eq(contacts.name, looseField as never))
+      .execute();
+
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toContain("Unsupported filter operand");
+    expect(mock.spy?.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- return structured `Result` errors when query building fails for invalid entity-id table refs
- reject unresolved object-like filter operands instead of serializing malformed OData like `[object Object]`
- add regression tests for both reported failure paths
- add a patch changeset for `@proofkit/fmodata`

## Testing
- `pnpm run ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid entity-id references and unresolved filter operands. The system now returns structured error results with clear error messages instead of throwing uncaught exceptions or producing malformed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->