### PR TITLE
Persist detected local MCP file in typegen config

### DIFF
--- a/.changeset/auto-set-webviewer-connected-file.md
+++ b/.changeset/auto-set-webviewer-connected-file.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/cli": patch
+---
+
+Init(webviewer): if local FM MCP reports exactly 1 connected file, persist it to `proofkit-typegen.config.jsonc` as `fmMcp.connectedFileName` during scaffold.

--- a/packages/cli/src/core/executeInitPlan.ts
+++ b/packages/cli/src/core/executeInitPlan.ts
@@ -20,7 +20,7 @@ import {
 import { DirectoryConflictError, FileSystemError, isCliError, UserCancelledError } from "~/core/errors.js";
 import { applyPackageJsonMutations } from "~/core/planInit.js";
 import type { InitPlan } from "~/core/types.js";
-import { normalizeImportAlias, replaceTextInFiles } from "~/utils/projectFiles.js";
+import { normalizeImportAlias, replaceTextInFiles, updateTypegenConfig } from "~/utils/projectFiles.js";
 
 const AGENT_METADATA_DIRS = new Set([".agents", ".claude", ".clawed", ".clinerules", ".cursor", ".windsurf"]);
 const IMPORT_ALIAS_WILDCARD_REGEX = /\*/g;
@@ -198,6 +198,7 @@ export const executeInitPlan = (plan: InitPlan) =>
       throw failure ?? Cause.squash(exit.cause);
     };
     const projectFilesFs = {
+      exists: (targetPath: string) => runFileSystemPromise(fs.exists(targetPath)),
       readdir: (targetPath: string) => runFileSystemPromise(fs.readdir(targetPath)),
       readFile: (targetPath: string) => runFileSystemPromise(fs.readFile(targetPath)),
       writeFile: (targetPath: string, content: string) => runFileSystemPromise(fs.writeFile(targetPath, content)),
@@ -303,6 +304,32 @@ export const executeInitPlan = (plan: InitPlan) =>
         plan.request.appType,
       );
       yield* settingsService.writeSettings(plan.targetDir, nextSettings);
+    }
+
+    if (plan.request.appType === "webviewer" && !plan.tasks.bootstrapFileMaker) {
+      const localFmMcp = yield* fileMakerService.detectLocalFmMcp();
+      const connectedFiles = localFmMcp.connectedFiles.filter(Boolean);
+      if (localFmMcp.healthy && connectedFiles.length === 1) {
+        const detectedFile = connectedFiles[0];
+        if (detectedFile) {
+          yield* Effect.tryPromise({
+            try: () =>
+              updateTypegenConfig(projectFilesFs, plan.targetDir, {
+                appType: "webviewer",
+                dataSourceName: "filemaker",
+                fmMcpBaseUrl: localFmMcp.baseUrl,
+                connectedFileName: detectedFile,
+              }),
+            catch: (cause) =>
+              new FileSystemError({
+                message: "Unable to persist local FileMaker file detection into typegen config.",
+                operation: "updateTypegenConfig",
+                path: plan.targetDir,
+                cause,
+              }),
+          });
+        }
+      }
     }
 
     if (plan.tasks.checkWebViewerAddon) {

--- a/packages/cli/src/utils/projectFiles.ts
+++ b/packages/cli/src/utils/projectFiles.ts
@@ -7,6 +7,7 @@ import type { PackageManager } from "~/utils/packageManager.js";
 
 const commonFileMakerLayoutPrefixes = ["API_", "API ", "dapi_", "dapi"];
 const TRAILING_SLASH_REGEX = /[^/]$/;
+const DEFAULT_FM_MCP_BASE_URL = "http://127.0.0.1:1365";
 const textFileExtensions = new Set([
   ".ts",
   ".tsx",
@@ -191,10 +192,12 @@ export async function updateTypegenConfig(
     nextDataSource.webviewerScriptName = "ExecuteDataApi";
   }
 
-  if (options.fmMcpBaseUrl) {
+  if (options.fmMcpBaseUrl || options.connectedFileName) {
     nextDataSource.fmMcp = {
       enabled: true,
-      baseUrl: options.fmMcpBaseUrl,
+      ...(options.fmMcpBaseUrl && options.fmMcpBaseUrl !== DEFAULT_FM_MCP_BASE_URL
+        ? { baseUrl: options.fmMcpBaseUrl }
+        : {}),
       ...(options.connectedFileName ? { connectedFileName: options.connectedFileName } : {}),
     };
   }

--- a/packages/cli/tests/executor.test.ts
+++ b/packages/cli/tests/executor.test.ts
@@ -149,7 +149,6 @@ describe("executeInitPlan command paths", () => {
     await Effect.runPromise(executeInitPlan(plan).pipe(makeTestLayer({ cwd, packageManager: "pnpm" })));
 
     const { typegenConfig } = await readScaffoldArtifacts(path.join(cwd, "local-mcp-app"));
-    expect(typegenConfig).toContain('"baseUrl": "http://127.0.0.1:1365"');
     expect(typegenConfig).toContain('"connectedFileName": "Selected.fmp12"');
   });
 
@@ -194,8 +193,54 @@ describe("executeInitPlan command paths", () => {
     await Effect.runPromise(executeInitPlan(plan).pipe(makeTestLayer({ cwd, packageManager: "pnpm" })));
 
     const { typegenConfig } = await readScaffoldArtifacts(path.join(cwd, "single-local-mcp-app"));
-    expect(typegenConfig).toContain('"baseUrl": "http://127.0.0.1:1365"');
     expect(typegenConfig).toContain('"connectedFileName": "OnlyOpen.fmp12"');
+  });
+
+  it("persists detected local MCP file into typegen config when webviewer setup skips filemaker bootstrap", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "proofkit-local-mcp-skip-bootstrap-"));
+
+    const plan = planInit(
+      makeInitRequest({
+        projectName: "skip-bootstrap-local-mcp-app",
+        scopedAppName: "skip-bootstrap-local-mcp-app",
+        appDir: "skip-bootstrap-local-mcp-app",
+        appType: "webviewer",
+        ui: "shadcn",
+        dataSource: "none",
+        packageManager: "pnpm",
+        noInstall: true,
+        noGit: true,
+        force: false,
+        cwd,
+        importAlias: "~/",
+        nonInteractive: true,
+        debug: false,
+        skipFileMakerSetup: false,
+        hasExplicitFileMakerInputs: false,
+      }),
+      {
+        templateDir: getSharedTemplateDir("vite-wv"),
+      },
+    );
+
+    await Effect.runPromise(
+      executeInitPlan(plan).pipe(
+        makeTestLayer({
+          cwd,
+          packageManager: "pnpm",
+          fileMaker: {
+            localFmMcp: {
+              healthy: true,
+              baseUrl: "http://127.0.0.1:1365",
+              connectedFiles: ["Autodetected.fmp12"],
+            },
+          },
+        }),
+      ),
+    );
+
+    const { typegenConfig } = await readScaffoldArtifacts(path.join(cwd, "skip-bootstrap-local-mcp-app"));
+    expect(typegenConfig).toContain('"connectedFileName": "Autodetected.fmp12"');
   });
 
   it("fails with a typed directory conflict in non-interactive mode", async () => {


### PR DESCRIPTION
## Summary
- Persist a detected single local FileMaker MCP connected file into `proofkit-typegen.config.jsonc` during webviewer scaffold.
- Skip writing the default MCP base URL when it matches the local default.
- Add coverage for the webviewer path that skips FileMaker bootstrap but still detects a local MCP file.

## Testing
- Added executor test for webviewer init with local MCP autodetection.
- Updated existing executor expectations to assert `connectedFileName` without requiring the default `baseUrl`.
- Not run: `pnpm run ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebViewer initialization now automatically detects and saves local FileMaker file connections to your project configuration during setup, eliminating manual configuration steps.

* **Improvements**
  * Enhanced FileMaker configuration with smarter detection and persistence of connected files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->