### PR TITLE
Fix FileMaker init to install webviewer addon before local MCP file check

### DIFF
--- a/.changeset/fifty-lobsters-remain.md
+++ b/.changeset/fifty-lobsters-remain.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/cli": patch
+---
+
+Fix FileMaker webviewer init flow to install local addon files before prompting that no FileMaker file is open in the local MCP server.

--- a/packages/cli/src/core/context.ts
+++ b/packages/cli/src/core/context.ts
@@ -164,6 +164,7 @@ export interface FileMakerBootstrapArtifacts {
 
 export interface FileMakerService {
   readonly detectLocalFmMcp: (baseUrl?: string) => Eff<FmMcpStatus, CliError>;
+  readonly installLocalWebViewerAddon: () => Eff<void, CliError>;
   readonly validateHostedServerUrl: (
     serverUrl: string,
     ottoPort?: number | null,

--- a/packages/cli/src/core/resolveInitRequest.ts
+++ b/packages/cli/src/core/resolveInitRequest.ts
@@ -464,6 +464,7 @@ function resolveFileMakerInputs({
 
       while (true) {
         const localFmMcp = yield* fileMakerService.detectLocalFmMcp();
+        yield* fileMakerService.installLocalWebViewerAddon();
         const selectedFile = localFmMcp.healthy ? yield* resolveLocalFmMcpFile(localFmMcp.connectedFiles) : undefined;
         if (localFmMcp.healthy && selectedFile) {
           console.info(`Using local ProofKit MCP file: ${selectedFile}`);

--- a/packages/cli/src/services/live.ts
+++ b/packages/cli/src/services/live.ts
@@ -24,6 +24,7 @@ import {
 } from "~/core/context.js";
 import { ExternalCommandError, FileMakerSetupError, FileSystemError, UserCancelledError } from "~/core/errors.js";
 import type { AppType, FileMakerInputs, ProofKitSettings, UIType } from "~/core/types.js";
+import { installFmAddonExplicitly } from "~/installers/install-fm-addon.js";
 import { openBrowser } from "~/utils/browserOpen.js";
 import { deleteJson, getJson, postJson } from "~/utils/http.js";
 import { detectUserPackageManager } from "~/utils/packageManager.js";
@@ -357,6 +358,17 @@ const fileMakerService = {
           cause,
         }),
     }),
+  installLocalWebViewerAddon: () =>
+    Effect.tryPromise({
+      try: async () => {
+        await installFmAddonExplicitly({ addonName: "wv" });
+      },
+      catch: (cause) =>
+        new FileMakerSetupError({
+          message: "Unable to install local ProofKit WebViewer add-on files.",
+          cause,
+        }),
+    }).pipe(Effect.asVoid),
   validateHostedServerUrl: (serverUrl: string, ottoPort?: number | null) =>
     Effect.gen(function* () {
       const normalizedUrl = normalizeUrl(serverUrl);

--- a/packages/cli/tests/resolve-init.test.ts
+++ b/packages/cli/tests/resolve-init.test.ts
@@ -392,52 +392,12 @@ describe("resolveInitRequest", () => {
       multiSearchSelect: [],
       confirm: [],
     };
-
-    const request = await Effect.runPromise(
-      resolveInitRequest("demo", {
-        noGit: true,
-        noInstall: true,
-        force: false,
-        default: false,
-        importAlias: "~/",
-        CI: false,
-        appType: "webviewer",
-        dataSource: "filemaker",
-      }).pipe(
-        makeTestLayer({
-          cwd: "/tmp",
-          packageManager: "pnpm",
-          nonInteractive: false,
-          prompts: {
-            select: ["skip"],
-          },
-          promptTranscript,
-          fileMaker: {
-            localFmMcp: {
-              healthy: true,
-              connectedFiles: [],
-            },
-          },
-        }),
-      ),
-    );
-
-    expect(request.fileMaker).toBeUndefined();
-    expect(request.skipFileMakerSetup).toBe(true);
-    expect(promptTranscript.select).toContainEqual({
-      message:
-        "ProofKit MCP Server is running, but no FileMaker file is open yet. Open one, then choose how to continue.",
-      options: ["retry", "hosted", "skip"],
-    });
-  });
-
-  it("retries local MCP detection, then reports the connected file", async () => {
-    const consoleTranscript: ConsoleTranscript = {
-      info: [],
-      warn: [],
-      error: [],
-      success: [],
-      note: [],
+    const tracker = {
+      commands: [],
+      gitInits: 0,
+      codegens: 0,
+      filemakerBootstraps: 0,
+      addonInstalls: 0,
     };
 
     const request = await Effect.runPromise(
@@ -455,6 +415,63 @@ describe("resolveInitRequest", () => {
           cwd: "/tmp",
           packageManager: "pnpm",
           nonInteractive: false,
+          tracker,
+          prompts: {
+            select: ["skip"],
+          },
+          promptTranscript,
+          fileMaker: {
+            localFmMcp: {
+              healthy: true,
+              connectedFiles: [],
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(request.fileMaker).toBeUndefined();
+    expect(request.skipFileMakerSetup).toBe(true);
+    expect(tracker.addonInstalls).toBe(1);
+    expect(promptTranscript.select).toContainEqual({
+      message:
+        "ProofKit MCP Server is running, but no FileMaker file is open yet. Open one, then choose how to continue.",
+      options: ["retry", "hosted", "skip"],
+    });
+  });
+
+  it("retries local MCP detection, then reports the connected file", async () => {
+    const consoleTranscript: ConsoleTranscript = {
+      info: [],
+      warn: [],
+      error: [],
+      success: [],
+      note: [],
+    };
+    const tracker = {
+      commands: [],
+      gitInits: 0,
+      codegens: 0,
+      filemakerBootstraps: 0,
+      addonInstalls: 0,
+    };
+
+    const request = await Effect.runPromise(
+      resolveInitRequest("demo", {
+        noGit: true,
+        noInstall: true,
+        force: false,
+        default: false,
+        importAlias: "~/",
+        CI: false,
+        appType: "webviewer",
+        dataSource: "filemaker",
+      }).pipe(
+        makeTestLayer({
+          cwd: "/tmp",
+          packageManager: "pnpm",
+          nonInteractive: false,
+          tracker,
           prompts: {
             select: ["retry"],
           },
@@ -479,6 +496,7 @@ describe("resolveInitRequest", () => {
       mode: "local-fm-mcp",
       fileName: "RetryConnected.fmp12",
     });
+    expect(tracker.addonInstalls).toBe(2);
     expect(consoleTranscript.info).toContain("Using local ProofKit MCP file: RetryConnected.fmp12");
   });
 

--- a/packages/cli/tests/test-layer.ts
+++ b/packages/cli/tests/test-layer.ts
@@ -64,6 +64,7 @@ export function makeTestLayer(options: {
     gitInits: number;
     codegens: number;
     filemakerBootstraps: number;
+    addonInstalls?: number;
   };
   fileMaker?: {
     localFmMcp?:
@@ -399,6 +400,12 @@ export function makeTestLayer(options: {
           healthy: next?.healthy ?? false,
           connectedFiles: next?.connectedFiles ?? [],
         });
+      },
+      installLocalWebViewerAddon: () => {
+        if (tracker) {
+          tracker.addonInstalls = (tracker.addonInstalls ?? 0) + 1;
+        }
+        return Effect.void;
       },
       validateHostedServerUrl: (serverUrl: string) => {
         if (options.failures?.validateHostedServerUrl) {


### PR DESCRIPTION
## Summary
- install local ProofKit WebViewer add-on files before checking for an open FileMaker file during CLI init
- add a dedicated FileMaker service hook for local webviewer add-on install in the live service
- cover initial prompt and retry flow with tests that assert add-on install attempts
- add a changeset for `@proofkit/cli`

## Testing
- `pnpm run ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FileMaker webviewer initialization sequence to ensure local add-on files are installed before checking for open FileMaker files in the local MCP server.

* **Tests**
  * Updated test suite to track and verify add-on installation attempts during FileMaker initialization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->