### PR TITLE
Split fmodata count into count-only and counted list

### DIFF
--- a/.changeset/split-fmodata-count-api.md
+++ b/.changeset/split-fmodata-count-api.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/fmodata": minor
+---
+
+Split the fmodata count API into 2 flows. `db.from(table).count()` now runs a count-only query against the `/$count` endpoint, while `db.from(table).list().count()` keeps the list query and returns `{ records, count }` from a single request. This improves pagination ergonomics and avoids forcing two requests when rows and total count are both needed.

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -3,9 +3,4 @@ version = 1
 name = "proofkit"
 
 [setup]
-script = ""
-
-[[actions]]
-name = "Run"
-icon = "run"
-command = "pnpm i"
+script = "pnpm i"

--- a/apps/docs/content/docs/fmodata/methods.mdx
+++ b/apps/docs/content/docs/fmodata/methods.mdx
@@ -12,6 +12,7 @@ Quick reference for all available methods and operators in `@proofkit/fmodata`.
 | Method | Description | Example |
 |--------|-------------|---------|
 | `list()` | Retrieve multiple records | `db.from(users).list().execute()` |
+| `count()` | Count records without fetching rows | `db.from(users).count().where(eq(users.active, true)).execute()` |
 | `get(id)` | Get a single record by ID | `db.from(users).get("user-123").execute()` |
 | `getSingleField(column)` | Get a single field value | `db.from(users).get("user-123").getSingleField(users.email).execute()` |
 | `single()` | Ensure exactly one record | `db.from(users).list().where(eq(...)).single().execute()` |
@@ -34,7 +35,7 @@ Quick reference for all available methods and operators in `@proofkit/fmodata`.
 | `orderBy(...columns)` | Sort results | `db.from(users).list().orderBy(asc(users.name)).execute()` |
 | `top(n)` | Limit results | `db.from(users).list().top(10).execute()` |
 | `skip(n)` | Skip records (pagination) | `db.from(users).list().top(10).skip(20).execute()` |
-| `count()` | Get total count | `db.from(users).list().count().execute()` |
+| `count()` | Include total count with a list query | `db.from(users).list().top(10).skip(20).count().execute()` |
 | `expand(table, builder?)` | Expand related records | `db.from(contacts).list().expand(users).execute()` |
 | `navigate(table)` | Navigate to related table | `db.from(contacts).get("id").navigate(users).execute()` |
 

--- a/apps/docs/content/docs/fmodata/queries.mdx
+++ b/apps/docs/content/docs/fmodata/queries.mdx
@@ -160,8 +160,11 @@ const result = await db.from(users).list().top(10).execute();
 // Skip records (pagination)
 const result = await db.from(users).list().top(10).skip(20).execute();
 
-// Count total records
-const result = await db.from(users).list().count().execute();
+// Count total records without fetching rows
+const total = await db.from(users).count().execute();
+
+// Fetch a page of rows and the total count in one request
+const page = await db.from(users).list().top(10).skip(20).count().execute();
 ```
 
 ## Selecting Fields
@@ -244,4 +247,3 @@ const result = await db
   .skip(0)
   .execute();
 ```
-

--- a/packages/fmodata/README.md
+++ b/packages/fmodata/README.md
@@ -384,8 +384,11 @@ const result = await db.from(users).list().top(10).execute();
 // Skip records (pagination)
 const result = await db.from(users).list().top(10).skip(20).execute();
 
-// Count total records
-const result = await db.from(users).list().count().execute();
+// Count total records without fetching rows
+const total = await db.from(users).count().execute();
+
+// Fetch a page of rows and the total count in one request
+const page = await db.from(users).list().top(10).skip(20).count().execute();
 ```
 
 ### Selecting Fields

--- a/packages/fmodata/src/client/batch-builder.ts
+++ b/packages/fmodata/src/client/batch-builder.ts
@@ -20,7 +20,11 @@ import { createClientRuntime } from "./runtime";
  */
 // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any ExecutableBuilder result type
 type ExtractTupleTypes<T extends readonly ExecutableBuilder<any>[]> = {
-  [K in keyof T]: T[K] extends ExecutableBuilder<infer U> ? U : never;
+  [K in keyof T]: T[K] extends {
+    processResponse(response: Response, options?: ExecuteOptions): Promise<Result<infer U>>;
+  }
+    ? U
+    : never;
 };
 
 /**

--- a/packages/fmodata/src/client/builders/read-builder-state.ts
+++ b/packages/fmodata/src/client/builders/read-builder-state.ts
@@ -10,6 +10,7 @@ export interface QueryReadBuilderState<TSchema> {
   expandConfigs: ExpandConfig[];
   singleMode: "exact" | "maybe" | false;
   isCountMode: boolean;
+  includeCountMode: boolean;
   fieldMapping?: Record<string, string>;
   systemColumns?: SystemColumnsOption;
   navigation?: NavigationConfig;
@@ -21,6 +22,7 @@ export function createInitialQueryReadBuilderState<TSchema>(): QueryReadBuilderS
     expandConfigs: [],
     singleMode: false,
     isCountMode: false,
+    includeCountMode: false,
   };
 }
 

--- a/packages/fmodata/src/client/builders/response-processor.ts
+++ b/packages/fmodata/src/client/builders/response-processor.ts
@@ -278,6 +278,13 @@ export async function processQueryResponse<T>(
   }
 
   if (includeCount) {
+    if (processedResponse.error) {
+      return {
+        data: undefined,
+        error: processedResponse.error,
+      };
+    }
+
     if (singleMode !== false) {
       return {
         data: undefined,

--- a/packages/fmodata/src/client/builders/response-processor.ts
+++ b/packages/fmodata/src/client/builders/response-processor.ts
@@ -1,9 +1,9 @@
-import { RecordCountMismatchError } from "../../errors";
+import { RecordCountMismatchError, ResponseStructureError } from "../../errors";
 import type { InternalLogger } from "../../logger";
 import type { FMTable } from "../../orm/table";
 import { getBaseTableConfig } from "../../orm/table";
 import { transformResponseFields } from "../../transform";
-import type { Result } from "../../types";
+import type { CountedListResult, Result } from "../../types";
 import type { ExpandValidationConfig } from "../../validation";
 import { validateListResponse, validateSingleResponse } from "../../validation";
 import { ExpandBuilder } from "./expand-builder";
@@ -227,6 +227,7 @@ export async function processQueryResponse<T>(
     skipValidation?: boolean;
     useEntityIds?: boolean;
     includeSpecialColumns?: boolean;
+    includeCount?: boolean;
     // Mapping from field names to output keys (for renamed fields in select)
     fieldMapping?: Record<string, string>;
     logger: InternalLogger;
@@ -241,6 +242,7 @@ export async function processQueryResponse<T>(
     skipValidation,
     useEntityIds,
     includeSpecialColumns,
+    includeCount,
     fieldMapping,
     logger,
   } = config;
@@ -272,6 +274,38 @@ export async function processQueryResponse<T>(
     processedResponse = {
       ...processedResponse,
       data: renameFieldsInResponse(processedResponse.data, fieldMapping),
+    };
+  }
+
+  if (includeCount) {
+    if (singleMode !== false) {
+      return {
+        data: undefined,
+        error: new ResponseStructureError("list response for count-enabled query", response),
+      };
+    }
+
+    const rawCount = response?.["@odata.count"];
+    let parsedCount = Number.NaN;
+    if (typeof rawCount === "number") {
+      parsedCount = rawCount;
+    } else if (typeof rawCount === "string" && rawCount.trim() !== "") {
+      parsedCount = Number(rawCount);
+    }
+
+    if (!Number.isFinite(parsedCount)) {
+      return {
+        data: undefined,
+        error: new ResponseStructureError("response with valid @odata.count", response),
+      };
+    }
+
+    return {
+      data: {
+        records: processedResponse.data as T[],
+        count: parsedCount,
+      } as CountedListResult<T>,
+      error: undefined,
     };
   }
 

--- a/packages/fmodata/src/client/count-builder.ts
+++ b/packages/fmodata/src/client/count-builder.ts
@@ -1,0 +1,172 @@
+import { Effect } from "effect";
+import buildQuery, { type QueryOptions } from "odata-query";
+import { requestFromService, runLayerResult } from "../effect";
+import type { FMODataErrorType } from "../errors";
+import { BuilderInvariantError, isFMODataError, ResponseStructureError } from "../errors";
+import type { FilterExpression } from "../orm/operators";
+import { type FMTable, getTableName, type InferSchemaOutputFromFMTable } from "../orm/table";
+import type { FMODataLayer, ODataConfig } from "../services";
+import type { ExecutableBuilder, ExecuteMethodOptions, ExecuteOptions, Result } from "../types";
+import { createODataRequest, mergeExecuteOptions } from "./builders/index";
+import { parseErrorResponse } from "./error-parser";
+import { type NavigationConfig, QueryUrlBuilder } from "./query/url-builder";
+import { createClientRuntime } from "./runtime";
+
+function normalizeCountBuildError(error: unknown): FMODataErrorType {
+  if (isFMODataError(error)) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new BuilderInvariantError("CountBuilder.execute", error.message, { cause: error });
+  }
+  return new BuilderInvariantError("CountBuilder.execute", String(error));
+}
+
+export class CountBuilder<
+  // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration
+  Occ extends FMTable<any, any>,
+  DatabaseIncludeSpecialColumns extends boolean = false,
+> implements ExecutableBuilder<number>
+{
+  private readonly occurrence: Occ;
+  private readonly layer: FMODataLayer;
+  private readonly config: ODataConfig;
+  private readonly urlBuilder: QueryUrlBuilder;
+  private filterExpression?: FilterExpression;
+  private readonly queryOptions: Partial<QueryOptions<InferSchemaOutputFromFMTable<Occ>>> = {};
+  private navigationConfig?: NavigationConfig;
+
+  constructor(config: {
+    occurrence: Occ;
+    layer: FMODataLayer;
+  }) {
+    this.occurrence = config.occurrence;
+    const runtime = createClientRuntime(config.layer);
+    this.layer = runtime.layer;
+    this.config = runtime.config;
+    this.urlBuilder = new QueryUrlBuilder(this.config.databaseName, this.occurrence, this.config.useEntityIds);
+  }
+
+  set navigation(navigation: NavigationConfig | undefined) {
+    this.navigationConfig = navigation;
+  }
+
+  where(expression: FilterExpression | string): CountBuilder<Occ, DatabaseIncludeSpecialColumns> {
+    if (typeof expression === "string") {
+      this.filterExpression = undefined;
+      this.queryOptions.filter = expression;
+      return this;
+    }
+
+    this.filterExpression = expression;
+    this.queryOptions.filter = undefined;
+    return this;
+  }
+
+  private buildQueryString(useEntityIds?: boolean): string {
+    const finalUseEntityIds = useEntityIds ?? this.config.useEntityIds;
+    const queryOptions = { ...this.queryOptions };
+
+    if (this.filterExpression) {
+      queryOptions.filter = this.filterExpression.toODataFilter(finalUseEntityIds);
+    }
+
+    queryOptions.count = undefined;
+    queryOptions.select = undefined;
+    queryOptions.expand = undefined;
+    queryOptions.top = undefined;
+    queryOptions.skip = undefined;
+    queryOptions.orderBy = undefined;
+
+    return buildQuery(queryOptions);
+  }
+
+  private parseCountValue(raw: unknown): number | ResponseStructureError {
+    let count = Number.NaN;
+    if (typeof raw === "number") {
+      count = raw;
+    } else if (typeof raw === "string" && raw.trim() !== "") {
+      count = Number(raw);
+    }
+    return Number.isFinite(count) ? count : new ResponseStructureError("numeric count response", raw);
+  }
+
+  execute<EO extends ExecuteOptions>(options?: ExecuteMethodOptions<EO>): Promise<Result<number>> {
+    const mergedOptions = mergeExecuteOptions(options, this.config.useEntityIds);
+    let queryString: string;
+    let url: string;
+
+    try {
+      queryString = this.buildQueryString(mergedOptions.useEntityIds);
+      url = this.urlBuilder.build(queryString, {
+        isCount: true,
+        useEntityIds: mergedOptions.useEntityIds,
+        navigation: this.navigationConfig,
+      });
+    } catch (error) {
+      return Promise.resolve({
+        data: undefined,
+        error: normalizeCountBuildError(error),
+      });
+    }
+
+    const pipeline = requestFromService(url, mergedOptions).pipe(
+      Effect.flatMap((data) => {
+        const parsed = this.parseCountValue(data);
+        return parsed instanceof ResponseStructureError ? Effect.fail(parsed) : Effect.succeed(parsed);
+      }),
+    );
+
+    return runLayerResult(this.layer, pipeline, "fmodata.query.count", {
+      "fmodata.table": getTableName(this.occurrence),
+    });
+  }
+
+  getQueryString(options?: { useEntityIds?: boolean }): string {
+    const useEntityIds = options?.useEntityIds ?? this.config.useEntityIds;
+    const queryString = this.buildQueryString(useEntityIds);
+    return this.urlBuilder.buildPath(queryString, {
+      isCount: true,
+      useEntityIds,
+      navigation: this.navigationConfig,
+    });
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: Request body can be any JSON-serializable value
+  getRequestConfig(): { method: string; url: string; body?: any } {
+    const queryString = this.buildQueryString(this.config.useEntityIds);
+    const url = this.urlBuilder.build(queryString, {
+      isCount: true,
+      useEntityIds: this.config.useEntityIds,
+      navigation: this.navigationConfig,
+    });
+
+    return {
+      method: "GET",
+      url,
+    };
+  }
+
+  toRequest(baseUrl: string, options?: ExecuteOptions): Request {
+    const config = this.getRequestConfig();
+    return createODataRequest(baseUrl, config, options);
+  }
+
+  async processResponse(response: Response, _options?: ExecuteOptions): Promise<Result<number>> {
+    if (!response.ok) {
+      const error = await parseErrorResponse(
+        response,
+        response.url || `/${this.config.databaseName}/${getTableName(this.occurrence)}/$count`,
+      );
+      return { data: undefined, error };
+    }
+
+    const raw = await response.text();
+    const parsed = this.parseCountValue(raw);
+    if (parsed instanceof ResponseStructureError) {
+      return { data: undefined, error: parsed };
+    }
+
+    return { data: parsed, error: undefined };
+  }
+}

--- a/packages/fmodata/src/client/entity-set.ts
+++ b/packages/fmodata/src/client/entity-set.ts
@@ -18,6 +18,7 @@ import {
 } from "../orm/table";
 import type { FMODataLayer, ODataConfig } from "../services";
 import { resolveTableId } from "./builders/table-utils";
+import { CountBuilder } from "./count-builder";
 import type { Database } from "./database";
 import { DeleteBuilder } from "./delete-builder";
 import { InsertBuilder } from "./insert-builder";
@@ -105,8 +106,16 @@ export class EntitySet<Occ extends FMTable<any, any>, DatabaseIncludeSpecialColu
     return builder;
   }
 
-  // biome-ignore lint/complexity/noBannedTypes: Empty object type represents no expands by default
-  list(): QueryBuilder<Occ, keyof InferSchemaOutputFromFMTable<Occ>, false, false, {}, DatabaseIncludeSpecialColumns> {
+  list(): QueryBuilder<
+    Occ,
+    keyof InferSchemaOutputFromFMTable<Occ>,
+    false,
+    false,
+    // biome-ignore lint/complexity/noBannedTypes: Empty object type represents no expands by default
+    {},
+    false,
+    DatabaseIncludeSpecialColumns
+  > {
     const builder = new QueryBuilder<
       Occ,
       keyof InferSchemaOutputFromFMTable<Occ>,
@@ -114,6 +123,7 @@ export class EntitySet<Occ extends FMTable<any, any>, DatabaseIncludeSpecialColu
       false,
       // biome-ignore lint/complexity/noBannedTypes: Empty object type represents no expands by default
       {},
+      false,
       DatabaseIncludeSpecialColumns
     >({
       occurrence: this.occurrence as Occ,
@@ -145,6 +155,7 @@ export class EntitySet<Occ extends FMTable<any, any>, DatabaseIncludeSpecialColu
           false,
           // biome-ignore lint/complexity/noBannedTypes: Empty object type represents no expands by default
           {},
+          false,
           DatabaseIncludeSpecialColumns
         >;
       }
@@ -161,6 +172,7 @@ export class EntitySet<Occ extends FMTable<any, any>, DatabaseIncludeSpecialColu
           false,
           // biome-ignore lint/complexity/noBannedTypes: Empty object type represents no expands by default
           {},
+          false,
           DatabaseIncludeSpecialColumns
         >;
       }
@@ -170,6 +182,15 @@ export class EntitySet<Occ extends FMTable<any, any>, DatabaseIncludeSpecialColu
     // Apply default pagination limit of 1000 records to prevent stack overflow
     // with large datasets. Users can override with .top() if needed.
     return this.applyNavigationContext(builder).top(1000);
+  }
+
+  count(): CountBuilder<Occ, DatabaseIncludeSpecialColumns> {
+    const builder = new CountBuilder<Occ, DatabaseIncludeSpecialColumns>({
+      occurrence: this.occurrence,
+      layer: this.layer,
+    });
+
+    return this.applyNavigationContext(builder);
   }
 
   get(

--- a/packages/fmodata/src/client/query/index.ts
+++ b/packages/fmodata/src/client/query/index.ts
@@ -7,6 +7,7 @@ export type { ExpandConfig } from "../builders/shared-types";
 
 // Export types
 export type {
+  CountedListResult,
   ExpandedRelations,
   QueryReturnType,
   TypeSafeOrderBy,

--- a/packages/fmodata/src/client/query/query-builder.ts
+++ b/packages/fmodata/src/client/query/query-builder.ts
@@ -46,7 +46,7 @@ import { type NavigationConfig, QueryUrlBuilder } from "./url-builder";
 
 export type { ExpandedRelations } from "../builders/index";
 // Re-export types for backward compatibility
-export type { QueryReturnType, SystemColumnsOption, TypeSafeOrderBy } from "./types";
+export type { CountedListResult, QueryReturnType, SystemColumnsOption, TypeSafeOrderBy } from "./types";
 
 /**
  * Default maximum number of records to return in a list query.
@@ -76,11 +76,20 @@ export class QueryBuilder<
   IsCount extends boolean = false,
   // biome-ignore lint/complexity/noBannedTypes: Empty object type represents no expands by default
   Expands extends ExpandedRelations = {},
+  IncludeCount extends boolean = false,
   DatabaseIncludeSpecialColumns extends boolean = false,
   SystemCols extends SystemColumnsOption | undefined = undefined,
 > implements
     ExecutableBuilder<
-      QueryReturnType<InferSchemaOutputFromFMTable<Occ>, Selected, SingleMode, IsCount, Expands, SystemCols>
+      QueryReturnType<
+        InferSchemaOutputFromFMTable<Occ>,
+        Selected,
+        SingleMode,
+        IsCount,
+        Expands,
+        IncludeCount,
+        SystemCols
+      >
     >
 {
   private readState = createInitialQueryReadBuilderState<InferSchemaOutputFromFMTable<Occ>>();
@@ -129,6 +138,16 @@ export class QueryBuilder<
   private set isCountMode(isCountMode: IsCount) {
     this.readState = cloneQueryReadBuilderState(this.readState, {
       isCountMode,
+    });
+  }
+
+  private get includeCountMode(): IncludeCount {
+    return this.readState.includeCountMode as IncludeCount;
+  }
+
+  private set includeCountMode(includeCountMode: IncludeCount) {
+    this.readState = cloneQueryReadBuilderState(this.readState, {
+      includeCountMode,
     });
   }
 
@@ -217,21 +236,33 @@ export class QueryBuilder<
       | Record<string, Column<any, any, ExtractTableName<Occ>>> = Selected,
     NewSingle extends "exact" | "maybe" | false = SingleMode,
     NewCount extends boolean = IsCount,
+    NewIncludeCount extends boolean = IncludeCount,
     NewSystemCols extends SystemColumnsOption | undefined = SystemCols,
   >(changes: {
     selectedFields?: NewSelected;
     singleMode?: NewSingle;
     isCountMode?: NewCount;
+    includeCountMode?: NewIncludeCount;
     queryOptions?: Partial<QueryOptions<InferSchemaOutputFromFMTable<Occ>>>;
     fieldMapping?: Record<string, string>;
     systemColumns?: NewSystemCols;
-  }): QueryBuilder<Occ, NewSelected, NewSingle, NewCount, Expands, DatabaseIncludeSpecialColumns, NewSystemCols> {
+  }): QueryBuilder<
+    Occ,
+    NewSelected,
+    NewSingle,
+    NewCount,
+    Expands,
+    NewIncludeCount,
+    DatabaseIncludeSpecialColumns,
+    NewSystemCols
+  > {
     const newBuilder = new QueryBuilder<
       Occ,
       NewSelected,
       NewSingle,
       NewCount,
       Expands,
+      NewIncludeCount,
       DatabaseIncludeSpecialColumns,
       NewSystemCols
     >({
@@ -245,6 +276,8 @@ export class QueryBuilder<
       singleMode: (changes.singleMode ?? this.readState.singleMode) as any,
       // biome-ignore lint/suspicious/noExplicitAny: Type assertion for generic type parameter
       isCountMode: (changes.isCountMode ?? this.readState.isCountMode) as any,
+      // biome-ignore lint/suspicious/noExplicitAny: Type assertion for generic type parameter
+      includeCountMode: (changes.includeCountMode ?? this.readState.includeCountMode) as any,
       fieldMapping: "fieldMapping" in changes ? changes.fieldMapping : this.readState.fieldMapping,
       systemColumns: changes.systemColumns !== undefined ? changes.systemColumns : this.readState.systemColumns,
       navigation: this.readState.navigation,
@@ -287,6 +320,7 @@ export class QueryBuilder<
     SingleMode,
     IsCount,
     Expands,
+    IncludeCount,
     DatabaseIncludeSpecialColumns,
     undefined
   >;
@@ -298,7 +332,7 @@ export class QueryBuilder<
   >(
     fields: TSelect,
     systemColumns?: TSystemCols,
-  ): QueryBuilder<Occ, TSelect, SingleMode, IsCount, Expands, DatabaseIncludeSpecialColumns, TSystemCols>;
+  ): QueryBuilder<Occ, TSelect, SingleMode, IsCount, Expands, IncludeCount, DatabaseIncludeSpecialColumns, TSystemCols>;
   // biome-ignore lint/suspicious/noExplicitAny: Implementation signature hidden from callers
   select(fields: any, systemColumns?: any): any {
     if (fields === "all") {
@@ -348,7 +382,16 @@ export class QueryBuilder<
    */
   where(
     expression: FilterExpression | string,
-  ): QueryBuilder<Occ, Selected, SingleMode, IsCount, Expands, DatabaseIncludeSpecialColumns, SystemCols> {
+  ): QueryBuilder<
+    Occ,
+    Selected,
+    SingleMode,
+    IsCount,
+    Expands,
+    IncludeCount,
+    DatabaseIncludeSpecialColumns,
+    SystemCols
+  > {
     // Handle raw string filters (escape hatch)
     if (typeof expression === "string") {
       this.setFilterExpression(undefined);
@@ -400,7 +443,16 @@ export class QueryBuilder<
           // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
           ...Array<Column<any, any, ExtractTableName<Occ>> | OrderByExpression<ExtractTableName<Occ>>>,
         ]
-  ): QueryBuilder<Occ, Selected, SingleMode, IsCount, Expands, DatabaseIncludeSpecialColumns, SystemCols> {
+  ): QueryBuilder<
+    Occ,
+    Selected,
+    SingleMode,
+    IsCount,
+    Expands,
+    IncludeCount,
+    DatabaseIncludeSpecialColumns,
+    SystemCols
+  > {
     const tableName = getTableName(this.occurrence);
 
     // Handle variadic arguments (multiple fields)
@@ -520,14 +572,32 @@ export class QueryBuilder<
 
   top(
     count: number,
-  ): QueryBuilder<Occ, Selected, SingleMode, IsCount, Expands, DatabaseIncludeSpecialColumns, SystemCols> {
+  ): QueryBuilder<
+    Occ,
+    Selected,
+    SingleMode,
+    IsCount,
+    Expands,
+    IncludeCount,
+    DatabaseIncludeSpecialColumns,
+    SystemCols
+  > {
     this.patchQueryOptions({ top: count });
     return this;
   }
 
   skip(
     count: number,
-  ): QueryBuilder<Occ, Selected, SingleMode, IsCount, Expands, DatabaseIncludeSpecialColumns, SystemCols> {
+  ): QueryBuilder<
+    Occ,
+    Selected,
+    SingleMode,
+    IsCount,
+    Expands,
+    IncludeCount,
+    DatabaseIncludeSpecialColumns,
+    SystemCols
+  > {
     this.patchQueryOptions({ skip: count });
     return this;
   }
@@ -548,9 +618,9 @@ export class QueryBuilder<
     targetTable: ValidExpandTarget<Occ, TargetTable>,
     callback?: (
       // biome-ignore lint/complexity/noBannedTypes: Empty object type represents no expands in initial builder
-      builder: QueryBuilder<TargetTable, keyof InferSchemaOutputFromFMTable<TargetTable>, false, false, {}>,
+      builder: QueryBuilder<TargetTable, keyof InferSchemaOutputFromFMTable<TargetTable>, false, false, {}, false>,
       // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any QueryBuilder configuration
-    ) => QueryBuilder<TargetTable, TSelected, any, any, TNestedExpands>,
+    ) => QueryBuilder<TargetTable, TSelected, any, any, TNestedExpands, any, any>,
   ): QueryBuilder<
     Occ,
     Selected,
@@ -563,6 +633,7 @@ export class QueryBuilder<
         nested: TNestedExpands;
       };
     },
+    IncludeCount,
     DatabaseIncludeSpecialColumns,
     SystemCols
   > {
@@ -574,6 +645,7 @@ export class QueryBuilder<
       false,
       // biome-ignore lint/complexity/noBannedTypes: Empty object type represents no expands in new builder
       {},
+      false,
       DatabaseIncludeSpecialColumns
     >;
     const expandConfig = this.expandBuilder.processExpand<TargetTable, TargetBuilder>(
@@ -582,7 +654,7 @@ export class QueryBuilder<
       callback as ((builder: TargetBuilder) => TargetBuilder) | undefined,
       () =>
         // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any QueryBuilder configuration
-        new QueryBuilder<TargetTable, any, any, any, any, DatabaseIncludeSpecialColumns, undefined>({
+        new QueryBuilder<TargetTable, any, any, any, any, any, DatabaseIncludeSpecialColumns, undefined>({
           occurrence: targetTable,
           layer: this.layer,
         }),
@@ -595,17 +667,38 @@ export class QueryBuilder<
     return this as any;
   }
 
-  single(): QueryBuilder<Occ, Selected, "exact", IsCount, Expands, DatabaseIncludeSpecialColumns, SystemCols> {
+  single(
+    this: QueryBuilder<Occ, Selected, false, IsCount, Expands, false, DatabaseIncludeSpecialColumns, SystemCols>,
+  ): QueryBuilder<Occ, Selected, "exact", IsCount, Expands, false, DatabaseIncludeSpecialColumns, SystemCols> {
+    if (this.readState.includeCountMode) {
+      throw new BuilderInvariantError("QueryBuilder.single", "count-enabled list queries cannot use single()");
+    }
     return this.cloneWithChanges({ singleMode: "exact" as const });
   }
 
-  maybeSingle(): QueryBuilder<Occ, Selected, "maybe", IsCount, Expands, DatabaseIncludeSpecialColumns, SystemCols> {
+  maybeSingle(
+    this: QueryBuilder<Occ, Selected, false, IsCount, Expands, false, DatabaseIncludeSpecialColumns, SystemCols>,
+  ): QueryBuilder<Occ, Selected, "maybe", IsCount, Expands, false, DatabaseIncludeSpecialColumns, SystemCols> {
+    if (this.readState.includeCountMode) {
+      throw new BuilderInvariantError(
+        "QueryBuilder.maybeSingle",
+        "count-enabled list queries cannot use maybeSingle()",
+      );
+    }
     return this.cloneWithChanges({ singleMode: "maybe" as const });
   }
 
-  count(): QueryBuilder<Occ, Selected, SingleMode, true, Expands, DatabaseIncludeSpecialColumns, SystemCols> {
+  count(
+    this: QueryBuilder<Occ, Selected, false, IsCount, Expands, false, DatabaseIncludeSpecialColumns, SystemCols>,
+  ): QueryBuilder<Occ, Selected, false, IsCount, Expands, true, DatabaseIncludeSpecialColumns, SystemCols> {
+    if (this.readState.singleMode !== false) {
+      throw new BuilderInvariantError(
+        "QueryBuilder.count",
+        "single() and maybeSingle() cannot be combined with count()",
+      );
+    }
     return this.cloneWithChanges({
-      isCountMode: true as const,
+      includeCountMode: true as const,
       queryOptions: { count: true },
     });
   }
@@ -663,7 +756,15 @@ export class QueryBuilder<
     Result<
       ConditionallyWithODataAnnotations<
         ConditionallyWithSpecialColumns<
-          QueryReturnType<InferSchemaOutputFromFMTable<Occ>, Selected, SingleMode, IsCount, Expands, SystemCols>,
+          QueryReturnType<
+            InferSchemaOutputFromFMTable<Occ>,
+            Selected,
+            SingleMode,
+            IsCount,
+            Expands,
+            IncludeCount,
+            SystemCols
+          >,
           // Use the merged value: if explicitly provided in options, use that; otherwise use database default
           NormalizeIncludeSpecialColumns<EO["includeSpecialColumns"], DatabaseIncludeSpecialColumns>,
           // Check if select was applied: if Selected is Record (object select) or a subset of keys, select was applied
@@ -680,7 +781,15 @@ export class QueryBuilder<
   > {
     type ExecuteResponse = ConditionallyWithODataAnnotations<
       ConditionallyWithSpecialColumns<
-        QueryReturnType<InferSchemaOutputFromFMTable<Occ>, Selected, SingleMode, IsCount, Expands, SystemCols>,
+        QueryReturnType<
+          InferSchemaOutputFromFMTable<Occ>,
+          Selected,
+          SingleMode,
+          IsCount,
+          Expands,
+          IncludeCount,
+          SystemCols
+        >,
         NormalizeIncludeSpecialColumns<EO["includeSpecialColumns"], DatabaseIncludeSpecialColumns>,
         // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
         Selected extends Record<string, Column<any, any, any>>
@@ -759,6 +868,7 @@ export class QueryBuilder<
               skipValidation: options?.skipValidation,
               useEntityIds: mergedOptions.useEntityIds,
               includeSpecialColumns: mergedOptions.includeSpecialColumns,
+              includeCount: this.readState.includeCountMode,
               fieldMapping: this.readState.fieldMapping,
               logger: this.logger,
             }),
@@ -810,7 +920,17 @@ export class QueryBuilder<
     response: Response,
     options?: ExecuteOptions,
   ): Promise<
-    Result<QueryReturnType<InferSchemaOutputFromFMTable<Occ>, Selected, SingleMode, IsCount, Expands, SystemCols>>
+    Result<
+      QueryReturnType<
+        InferSchemaOutputFromFMTable<Occ>,
+        Selected,
+        SingleMode,
+        IsCount,
+        Expands,
+        IncludeCount,
+        SystemCols
+      >
+    >
   > {
     // Check for error responses (important for batch operations)
     if (!response.ok) {
@@ -885,6 +1005,7 @@ export class QueryBuilder<
       skipValidation: options?.skipValidation,
       useEntityIds: mergedOptions.useEntityIds,
       includeSpecialColumns: mergedOptions.includeSpecialColumns,
+      includeCount: this.readState.includeCountMode,
       fieldMapping: this.readState.fieldMapping,
       logger: this.logger,
     });

--- a/packages/fmodata/src/client/query/query-builder.ts
+++ b/packages/fmodata/src/client/query/query-builder.ts
@@ -69,7 +69,8 @@ type QueryBuilderHasSelect<
   // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration
   Occ extends FMTable<any, any>,
   Selected,
-> = Selected extends Record<string, Column<any, any, any>> // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+  // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+> = Selected extends Record<string, Column<any, any, any>>
   ? true
   : Selected extends keyof InferSchemaOutputFromFMTable<Occ>
     ? false

--- a/packages/fmodata/src/client/query/query-builder.ts
+++ b/packages/fmodata/src/client/query/query-builder.ts
@@ -65,6 +65,84 @@ function normalizeQueryBuildError(error: unknown): FMODataErrorType {
   return new BuilderInvariantError("QueryBuilder.execute", String(error));
 }
 
+type QueryBuilderHasSelect<
+  // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration
+  Occ extends FMTable<any, any>,
+  Selected,
+> = Selected extends Record<string, Column<any, any, any>> // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+  ? true
+  : Selected extends keyof InferSchemaOutputFromFMTable<Occ>
+    ? false
+    : true;
+
+type BaseQueryBuilderReturn<
+  // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration
+  Occ extends FMTable<any, any>,
+  Selected extends
+    | keyof InferSchemaOutputFromFMTable<Occ>
+    // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+    | Record<string, Column<any, any, ExtractTableName<Occ>>>,
+  SingleMode extends "exact" | "maybe" | false,
+  IsCount extends boolean,
+  Expands extends ExpandedRelations,
+  IncludeCount extends boolean,
+  SystemCols extends SystemColumnsOption | undefined,
+> = QueryReturnType<
+  InferSchemaOutputFromFMTable<Occ>,
+  Selected,
+  SingleMode,
+  IsCount,
+  Expands,
+  IncludeCount,
+  SystemCols
+>;
+
+type ExecutableQueryBuilderReturn<
+  // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration
+  Occ extends FMTable<any, any>,
+  Selected extends
+    | keyof InferSchemaOutputFromFMTable<Occ>
+    // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+    | Record<string, Column<any, any, ExtractTableName<Occ>>>,
+  SingleMode extends "exact" | "maybe" | false,
+  IsCount extends boolean,
+  Expands extends ExpandedRelations,
+  IncludeCount extends boolean,
+  SystemCols extends SystemColumnsOption | undefined,
+> =
+  | ConditionallyWithODataAnnotations<
+      ConditionallyWithSpecialColumns<
+        BaseQueryBuilderReturn<Occ, Selected, SingleMode, IsCount, Expands, IncludeCount, SystemCols>,
+        true,
+        QueryBuilderHasSelect<Occ, Selected>
+      >,
+      true
+    >
+  | ConditionallyWithODataAnnotations<
+      ConditionallyWithSpecialColumns<
+        BaseQueryBuilderReturn<Occ, Selected, SingleMode, IsCount, Expands, IncludeCount, SystemCols>,
+        true,
+        QueryBuilderHasSelect<Occ, Selected>
+      >,
+      false
+    >
+  | ConditionallyWithODataAnnotations<
+      ConditionallyWithSpecialColumns<
+        BaseQueryBuilderReturn<Occ, Selected, SingleMode, IsCount, Expands, IncludeCount, SystemCols>,
+        false,
+        QueryBuilderHasSelect<Occ, Selected>
+      >,
+      true
+    >
+  | ConditionallyWithODataAnnotations<
+      ConditionallyWithSpecialColumns<
+        BaseQueryBuilderReturn<Occ, Selected, SingleMode, IsCount, Expands, IncludeCount, SystemCols>,
+        false,
+        QueryBuilderHasSelect<Occ, Selected>
+      >,
+      false
+    >;
+
 export class QueryBuilder<
   // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration
   Occ extends FMTable<any, any>,
@@ -81,15 +159,7 @@ export class QueryBuilder<
   SystemCols extends SystemColumnsOption | undefined = undefined,
 > implements
     ExecutableBuilder<
-      QueryReturnType<
-        InferSchemaOutputFromFMTable<Occ>,
-        Selected,
-        SingleMode,
-        IsCount,
-        Expands,
-        IncludeCount,
-        SystemCols
-      >
+      ExecutableQueryBuilderReturn<Occ, Selected, SingleMode, IsCount, Expands, IncludeCount, SystemCols>
     >
 {
   private readState = createInitialQueryReadBuilderState<InferSchemaOutputFromFMTable<Occ>>();

--- a/packages/fmodata/src/client/query/types.ts
+++ b/packages/fmodata/src/client/query/types.ts
@@ -1,4 +1,5 @@
 import type { Column } from "../../orm/column";
+import type { CountedListResult } from "../../types";
 
 /**
  * Type-safe orderBy type that provides better DX than odata-query's default.
@@ -74,6 +75,8 @@ export interface SystemColumnsOption {
   ROWMODID?: boolean;
 }
 
+export type { CountedListResult } from "../../types";
+
 /**
  * Extract system columns type from SystemColumnsOption.
  * Returns an object type with ROWID and/or ROWMODID properties when set to true.
@@ -93,28 +96,38 @@ export type QueryReturnType<
   SingleMode extends "exact" | "maybe" | false,
   IsCount extends boolean,
   Expands extends ExpandedRelations,
+  IncludeCount extends boolean,
   SystemCols extends SystemColumnsOption | undefined = undefined,
 > = IsCount extends true
   ? number
-  : // Use tuple wrapping [Selected] extends [...] to prevent distribution over unions
-    // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
-    [Selected] extends [Record<string, Column<any, any, any, any>>]
-    ? SingleMode extends "exact"
-      ? MapSelectToReturnType<Selected, T> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>
-      : SingleMode extends "maybe"
-        ?
-            | (MapSelectToReturnType<Selected, T> &
-                ResolveExpandedRelations<Expands> &
-                SystemColumnsFromOption<SystemCols>)
-            | null
-        : (MapSelectToReturnType<Selected, T> &
-            ResolveExpandedRelations<Expands> &
-            SystemColumnsFromOption<SystemCols>)[]
-    : // Use tuple wrapping to prevent distribution over union of keys
-      [Selected] extends [keyof T]
+  : IncludeCount extends true
+    ? CountedListResult<
+        // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+        [Selected] extends [Record<string, Column<any, any, any, any>>]
+          ? MapSelectToReturnType<Selected, T> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>
+          : [Selected] extends [keyof T]
+            ? Pick<T, Selected> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>
+            : never
+      >
+    : // Use tuple wrapping [Selected] extends [...] to prevent distribution over unions
+      // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+      [Selected] extends [Record<string, Column<any, any, any, any>>]
       ? SingleMode extends "exact"
-        ? Pick<T, Selected> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>
+        ? MapSelectToReturnType<Selected, T> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>
         : SingleMode extends "maybe"
-          ? (Pick<T, Selected> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>) | null
-          : (Pick<T, Selected> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>)[]
-      : never;
+          ?
+              | (MapSelectToReturnType<Selected, T> &
+                  ResolveExpandedRelations<Expands> &
+                  SystemColumnsFromOption<SystemCols>)
+              | null
+          : (MapSelectToReturnType<Selected, T> &
+              ResolveExpandedRelations<Expands> &
+              SystemColumnsFromOption<SystemCols>)[]
+      : // Use tuple wrapping to prevent distribution over union of keys
+        [Selected] extends [keyof T]
+        ? SingleMode extends "exact"
+          ? Pick<T, Selected> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>
+          : SingleMode extends "maybe"
+            ? (Pick<T, Selected> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>) | null
+            : (Pick<T, Selected> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>)[]
+        : never;

--- a/packages/fmodata/src/client/query/url-builder.ts
+++ b/packages/fmodata/src/client/query/url-builder.ts
@@ -52,61 +52,7 @@ export class QueryUrlBuilder {
       navigation?: NavigationConfig;
     },
   ): string {
-    const effectiveUseEntityIds = options.useEntityIds ?? this.useEntityIds;
-    const tableId = resolveTableId(this.occurrence, getTableName(this.occurrence), effectiveUseEntityIds);
-
-    const navigation = options.navigation;
-    if (navigation?.recordId && navigation?.relation) {
-      return this.buildRecordNavigation(queryString, tableId, navigation, effectiveUseEntityIds);
-    }
-    if (navigation?.relation) {
-      return this.buildEntitySetNavigation(queryString, tableId, navigation, effectiveUseEntityIds);
-    }
-    if (options.isCount) {
-      return `/${this.databaseName}/${tableId}/$count${queryString}`;
-    }
-    return `/${this.databaseName}/${tableId}${queryString}`;
-  }
-
-  /**
-   * Builds URL for record navigation: /database/sourceTable('recordId')/relation
-   * or /database/sourceTable/baseRelation('recordId')/relation for chained navigations
-   */
-  private buildRecordNavigation(
-    queryString: string,
-    _tableId: string,
-    navigation: NavigationConfig,
-    useEntityIds: boolean,
-  ): string {
-    const sourceTable = useEntityIds
-      ? (navigation.sourceTableEntityId ?? navigation.sourceTableName)
-      : navigation.sourceTableName;
-    const baseRelation = useEntityIds
-      ? (navigation.baseRelationEntityId ?? navigation.baseRelation)
-      : navigation.baseRelation;
-    const relation = useEntityIds ? (navigation.relationEntityId ?? navigation.relation) : navigation.relation;
-    const { recordId } = navigation;
-    const base = baseRelation ? `${sourceTable}/${baseRelation}('${recordId}')` : `${sourceTable}('${recordId}')`;
-    return `/${this.databaseName}/${base}/${relation}${queryString}`;
-  }
-
-  /**
-   * Builds URL for entity set navigation: /database/sourceTable/relation
-   * or /database/basePath/relation for chained navigations
-   */
-  private buildEntitySetNavigation(
-    queryString: string,
-    _tableId: string,
-    navigation: NavigationConfig,
-    useEntityIds: boolean,
-  ): string {
-    const sourceTable = useEntityIds
-      ? (navigation.sourceTableEntityId ?? navigation.sourceTableName)
-      : navigation.sourceTableName;
-    const basePath = useEntityIds ? (navigation.basePathEntityId ?? navigation.basePath) : navigation.basePath;
-    const relation = useEntityIds ? (navigation.relationEntityId ?? navigation.relation) : navigation.relation;
-    const base = basePath || sourceTable;
-    return `/${this.databaseName}/${base}/${relation}${queryString}`;
+    return `/${this.databaseName}${this.buildPath(queryString, options)}`;
   }
 
   /**

--- a/packages/fmodata/src/client/query/url-builder.ts
+++ b/packages/fmodata/src/client/query/url-builder.ts
@@ -113,10 +113,14 @@ export class QueryUrlBuilder {
    * Builds a query string path (without database prefix) for getQueryString().
    * Used when the full URL is not needed.
    */
-  buildPath(queryString: string, options?: { useEntityIds?: boolean; navigation?: NavigationConfig }): string {
+  buildPath(
+    queryString: string,
+    options?: { isCount?: boolean; useEntityIds?: boolean; navigation?: NavigationConfig },
+  ): string {
     const effectiveUseEntityIds = options?.useEntityIds ?? this.useEntityIds;
     const navigation = options?.navigation;
     const tableId = resolveTableId(this.occurrence, getTableName(this.occurrence), effectiveUseEntityIds);
+    const suffix = options?.isCount ? "/$count" : "";
 
     if (navigation?.recordId && navigation?.relation) {
       const sourceTable = effectiveUseEntityIds
@@ -130,7 +134,7 @@ export class QueryUrlBuilder {
         : navigation.relation;
       const { recordId } = navigation;
       const base = baseRelation ? `${sourceTable}/${baseRelation}('${recordId}')` : `${sourceTable}('${recordId}')`;
-      return queryString ? `/${base}/${relation}${queryString}` : `/${base}/${relation}`;
+      return queryString ? `/${base}/${relation}${suffix}${queryString}` : `/${base}/${relation}${suffix}`;
     }
     if (navigation?.relation) {
       const sourceTable = effectiveUseEntityIds
@@ -143,9 +147,9 @@ export class QueryUrlBuilder {
         ? (navigation.relationEntityId ?? navigation.relation)
         : navigation.relation;
       const base = basePath || sourceTable;
-      return queryString ? `/${base}/${relation}${queryString}` : `/${base}/${relation}`;
+      return queryString ? `/${base}/${relation}${suffix}${queryString}` : `/${base}/${relation}${suffix}`;
     }
-    return queryString ? `/${tableId}${queryString}` : `/${tableId}`;
+    return queryString ? `/${tableId}${suffix}${queryString}` : `/${tableId}${suffix}`;
   }
 
   /**

--- a/packages/fmodata/src/client/record-builder.ts
+++ b/packages/fmodata/src/client/record-builder.ts
@@ -82,6 +82,94 @@ export type RecordReturnType<
       ? Pick<Schema, Selected> & ResolveExpandedRelations<Expands> & SystemColumnsFromOption<SystemCols>
       : never;
 
+type RecordBuilderHasSelect<
+  // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration
+  Occ extends FMTable<any, any>,
+  IsSingleField extends boolean,
+  Selected,
+> = IsSingleField extends true
+  ? false
+  : // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+    Selected extends Record<string, Column<any, any, any>>
+    ? true
+    : Selected extends keyof InferSchemaOutputFromFMTable<NonNullable<Occ>>
+      ? false
+      : true;
+
+type ExecutableRecordBuilderReturn<
+  // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration
+  Occ extends FMTable<any, any>,
+  IsSingleField extends boolean,
+  // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+  FieldColumn extends Column<any, any, any, any> | undefined,
+  Selected extends
+    | keyof InferSchemaOutputFromFMTable<NonNullable<Occ>>
+    // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any Column configuration
+    | Record<string, Column<any, any, ExtractTableName<NonNullable<Occ>>>>,
+  Expands extends ExpandedRelations,
+  SystemCols extends SystemColumnsOption | undefined,
+> =
+  | ConditionallyWithODataAnnotations<
+      ConditionallyWithSpecialColumns<
+        RecordReturnType<
+          InferSchemaOutputFromFMTable<NonNullable<Occ>>,
+          IsSingleField,
+          FieldColumn,
+          Selected,
+          Expands,
+          SystemCols
+        >,
+        true,
+        RecordBuilderHasSelect<Occ, IsSingleField, Selected>
+      >,
+      true
+    >
+  | ConditionallyWithODataAnnotations<
+      ConditionallyWithSpecialColumns<
+        RecordReturnType<
+          InferSchemaOutputFromFMTable<NonNullable<Occ>>,
+          IsSingleField,
+          FieldColumn,
+          Selected,
+          Expands,
+          SystemCols
+        >,
+        true,
+        RecordBuilderHasSelect<Occ, IsSingleField, Selected>
+      >,
+      false
+    >
+  | ConditionallyWithODataAnnotations<
+      ConditionallyWithSpecialColumns<
+        RecordReturnType<
+          InferSchemaOutputFromFMTable<NonNullable<Occ>>,
+          IsSingleField,
+          FieldColumn,
+          Selected,
+          Expands,
+          SystemCols
+        >,
+        false,
+        RecordBuilderHasSelect<Occ, IsSingleField, Selected>
+      >,
+      true
+    >
+  | ConditionallyWithODataAnnotations<
+      ConditionallyWithSpecialColumns<
+        RecordReturnType<
+          InferSchemaOutputFromFMTable<NonNullable<Occ>>,
+          IsSingleField,
+          FieldColumn,
+          Selected,
+          Expands,
+          SystemCols
+        >,
+        false,
+        RecordBuilderHasSelect<Occ, IsSingleField, Selected>
+      >,
+      false
+    >;
+
 export class RecordBuilder<
   // biome-ignore lint/suspicious/noExplicitAny: Accepts any FMTable configuration, default allows untyped tables
   Occ extends FMTable<any, any> = FMTable<any, any>,
@@ -98,16 +186,7 @@ export class RecordBuilder<
   DatabaseIncludeSpecialColumns extends boolean = false,
   SystemCols extends SystemColumnsOption | undefined = undefined,
 > implements
-    ExecutableBuilder<
-      RecordReturnType<
-        InferSchemaOutputFromFMTable<NonNullable<Occ>>,
-        IsSingleField,
-        FieldColumn,
-        Selected,
-        Expands,
-        SystemCols
-      >
-    >
+    ExecutableBuilder<ExecutableRecordBuilderReturn<Occ, IsSingleField, FieldColumn, Selected, Expands, SystemCols>>
 {
   private readonly table: Occ;
   private readonly recordId: string | number;

--- a/packages/fmodata/src/client/record-builder.ts
+++ b/packages/fmodata/src/client/record-builder.ts
@@ -406,9 +406,9 @@ export class RecordBuilder<
   >(
     targetTable: ValidExpandTarget<Occ, TargetTable>,
     callback?: (
-      builder: QueryBuilder<TargetTable, keyof InferSchemaOutputFromFMTable<TargetTable>, false, false, {}>,
+      builder: QueryBuilder<TargetTable, keyof InferSchemaOutputFromFMTable<TargetTable>, false, false, {}, false>,
       // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any QueryBuilder configuration
-    ) => QueryBuilder<TargetTable, TSelected, any, any, TNestedExpands>,
+    ) => QueryBuilder<TargetTable, TSelected, any, any, TNestedExpands, any, any>,
   ): RecordBuilder<
     Occ,
     false,
@@ -451,14 +451,21 @@ export class RecordBuilder<
 
     // Use ExpandBuilder.processExpand to handle the expand logic
     const expandBuilder = new ExpandBuilder(this.config.useEntityIds, this.logger);
-    type TargetBuilder = QueryBuilder<TargetTable, keyof InferSchemaOutputFromFMTable<TargetTable>, false, false, {}>;
+    type TargetBuilder = QueryBuilder<
+      TargetTable,
+      keyof InferSchemaOutputFromFMTable<TargetTable>,
+      false,
+      false,
+      {},
+      false
+    >;
     const expandConfig = expandBuilder.processExpand<TargetTable, TargetBuilder>(
       targetTable,
       this.table ?? undefined,
       callback as ((builder: TargetBuilder) => TargetBuilder) | undefined,
       () =>
         // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any QueryBuilder configuration
-        new QueryBuilder<TargetTable, any, any, any, any, DatabaseIncludeSpecialColumns, undefined>({
+        new QueryBuilder<TargetTable, any, any, any, any, any, DatabaseIncludeSpecialColumns, undefined>({
           occurrence: targetTable,
           layer: this.layer,
         }),
@@ -480,6 +487,7 @@ export class RecordBuilder<
     false,
     false,
     {},
+    false,
     DatabaseIncludeSpecialColumns,
     undefined
   > {
@@ -498,7 +506,7 @@ export class RecordBuilder<
 
     // Create QueryBuilder with target table
     // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any QueryBuilder configuration
-    const builder = new QueryBuilder<TargetTable, any, any, any, any, DatabaseIncludeSpecialColumns, undefined>({
+    const builder = new QueryBuilder<TargetTable, any, any, any, any, any, DatabaseIncludeSpecialColumns, undefined>({
       occurrence: targetTable,
       layer: this.layer,
     });

--- a/packages/fmodata/src/index.ts
+++ b/packages/fmodata/src/index.ts
@@ -10,7 +10,7 @@ export {
   RetryLimitError,
   TimeoutError,
 } from "@fetchkit/ffetch";
-
+export type { CountBuilder } from "./client/count-builder";
 // Type-only exports - for type annotations only, not direct instantiation
 export type { Database } from "./client/database";
 export type { EntitySet } from "./client/entity-set";
@@ -118,6 +118,7 @@ export {
 export type {
   BatchItemResult,
   BatchResult,
+  CountedListResult,
   ExecuteMethodOptions,
   ExecuteOptions,
   FetchHandler,

--- a/packages/fmodata/src/types.ts
+++ b/packages/fmodata/src/types.ts
@@ -3,8 +3,13 @@ import type { StandardSchemaV1 } from "@standard-schema/spec";
 
 export type Auth = { username: string; password: string } | { apiKey: string };
 
-export interface ExecutableBuilder<T> {
-  execute(): Promise<Result<T>>;
+export interface CountedListResult<T> {
+  records: T[];
+  count: number;
+}
+
+export interface ExecutableBuilder<_T> {
+  execute(options?: ExecuteOptions): Promise<Result<unknown>>;
   // biome-ignore lint/suspicious/noExplicitAny: Request body can be any JSON-serializable value
   getRequestConfig(): { method: string; url: string; body?: any };
 
@@ -23,7 +28,7 @@ export interface ExecutableBuilder<T> {
    * @param options - Optional execution options (e.g., skipValidation, includeODataAnnotations)
    * @returns A typed Result with the builder's expected return type
    */
-  processResponse(response: Response, options?: ExecuteOptions): Promise<Result<T>>;
+  processResponse(response: Response, options?: ExecuteOptions): Promise<Result<unknown>>;
 }
 
 export interface ExecutionContext {
@@ -216,15 +221,20 @@ export function getAcceptHeader(includeODataAnnotations?: boolean): string {
   return includeODataAnnotations === true ? "application/json" : "application/json;odata.metadata=none";
 }
 
+type WithODataAnnotations<T> =
+  T extends CountedListResult<infer U>
+    ? CountedListResult<WithODataAnnotations<U>>
+    : T extends readonly (infer U)[]
+      ? WithODataAnnotations<U>[]
+      : // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any record shape
+        T extends Record<string, any>
+        ? T & ODataRecordMetadata
+        : T;
+
 export type ConditionallyWithODataAnnotations<
   T,
   IncludeODataAnnotations extends boolean,
-> = IncludeODataAnnotations extends true
-  ? T & {
-      "@id": string;
-      "@editLink": string;
-    }
-  : T;
+> = IncludeODataAnnotations extends true ? WithODataAnnotations<T> : T;
 
 /**
  * Normalizes includeSpecialColumns with a database-level default.
@@ -236,6 +246,19 @@ export type NormalizeIncludeSpecialColumns<
   IncludeSpecialColumns extends boolean | undefined,
   DatabaseDefault extends boolean = false,
 > = [IncludeSpecialColumns] extends [true] ? true : [IncludeSpecialColumns] extends [false] ? false : DatabaseDefault; // When undefined, use database-level default
+
+type WithSpecialColumnsDeep<T> =
+  T extends CountedListResult<infer U>
+    ? CountedListResult<WithSpecialColumnsDeep<U>>
+    : T extends readonly (infer U)[]
+      ? WithSpecialColumnsDeep<U>[]
+      : // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any record shape
+        T extends Record<string, any>
+        ? T & {
+            ROWID: number;
+            ROWMODID: number;
+          }
+        : T;
 
 /**
  * Conditionally adds ROWID and ROWMODID special columns to a type.
@@ -250,27 +273,7 @@ export type ConditionallyWithSpecialColumns<
   T,
   IncludeSpecialColumns extends boolean,
   HasSelect extends boolean,
-> = IncludeSpecialColumns extends true
-  ? HasSelect extends false
-    ? // Handle array types
-      T extends readonly (infer U)[]
-      ? // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any record shape
-        U extends Record<string, any>
-        ? (U & {
-            ROWID: number;
-            ROWMODID: number;
-          })[]
-        : T
-      : // Handle single object types
-        // biome-ignore lint/suspicious/noExplicitAny: Generic constraint accepting any record shape
-        T extends Record<string, any>
-        ? T & {
-            ROWID: number;
-            ROWMODID: number;
-          }
-        : T // Don't add special columns to primitives (e.g., single field queries)
-    : T
-  : T;
+> = IncludeSpecialColumns extends true ? (HasSelect extends false ? WithSpecialColumnsDeep<T> : T) : T;
 
 // Helper type to extract schema from a FMTable
 export type ExtractSchemaFromOccurrence<Occ> = Occ extends {

--- a/packages/fmodata/src/types.ts
+++ b/packages/fmodata/src/types.ts
@@ -8,8 +8,8 @@ export interface CountedListResult<T> {
   count: number;
 }
 
-export interface ExecutableBuilder<_T> {
-  execute(options?: ExecuteOptions): Promise<Result<unknown>>;
+export interface ExecutableBuilder<T> {
+  execute(options?: ExecuteOptions): Promise<Result<T>>;
   // biome-ignore lint/suspicious/noExplicitAny: Request body can be any JSON-serializable value
   getRequestConfig(): { method: string; url: string; body?: any };
 
@@ -28,7 +28,7 @@ export interface ExecutableBuilder<_T> {
    * @param options - Optional execution options (e.g., skipValidation, includeODataAnnotations)
    * @returns A typed Result with the builder's expected return type
    */
-  processResponse(response: Response, options?: ExecuteOptions): Promise<Result<unknown>>;
+  processResponse(response: Response, options?: ExecuteOptions): Promise<Result<T>>;
 }
 
 export interface ExecutionContext {

--- a/packages/fmodata/tests/batch.test.ts
+++ b/packages/fmodata/tests/batch.test.ts
@@ -48,6 +48,53 @@ describe("Batch Operations - Mock Tests", () => {
   const db = mock.database("test_db");
 
   describe("Mixed success/failure responses", () => {
+    it("should support list().count() and top-level count() in the same batch", async () => {
+      const mockBatchResponse = [
+        "--b_test_boundary",
+        "Content-Type: application/http",
+        "",
+        "HTTP/1.1 200 Ok",
+        "Content-Type: application/json;charset=utf-8",
+        "",
+        JSON.stringify({
+          "@odata.context": "test/$metadata#contacts",
+          "@odata.count": "2",
+          value: [
+            {
+              "@odata.id": "contacts('id-1')",
+              PrimaryKey: "id-1",
+              name: "First",
+              hobby: "Testing",
+            },
+          ],
+        }),
+        "--b_test_boundary",
+        "Content-Type: application/http",
+        "",
+        "HTTP/1.1 200 Ok",
+        "Content-Type: text/plain",
+        "",
+        "5",
+        "--b_test_boundary--",
+      ].join("\r\n");
+
+      const listWithCountQuery = db.from(contactsTO).list().where(eq(contactsTO.hobby, "Testing")).count();
+      const topLevelCountQuery = db.from(contactsTO).count().where(eq(contactsTO.hobby, "Testing"));
+
+      const result = await db.batch([listWithCountQuery, topLevelCountQuery]).execute({
+        fetchHandler: createBatchMockFetch(mockBatchResponse),
+      });
+
+      const [r1, r2] = result.results;
+      expect(r1?.error).toBeUndefined();
+      expect(r1?.data).toEqual({
+        count: 2,
+        records: [{ PrimaryKey: "id-1", hobby: "Testing", name: "First" }],
+      });
+      expect(r2?.error).toBeUndefined();
+      expect(r2?.data).toBe(5);
+    });
+
     it("should handle batch response where first succeeds, second fails (404), and third is truncated", async () => {
       // This mock response simulates a real FileMaker batch response where:
       // 1. First query succeeds with data

--- a/packages/fmodata/tests/e2e/e2e.test.ts
+++ b/packages/fmodata/tests/e2e/e2e.test.ts
@@ -138,7 +138,7 @@ describe("Basic E2E Operations", () => {
     const entitySet = db.from(contacts);
 
     // Get initial count
-    const initialCountResult = await entitySet.list().count().execute();
+    const initialCountResult = await entitySet.count().execute();
     assert(initialCountResult.data, "Expected data to be defined");
     const initialCount = initialCountResult.data;
 
@@ -164,7 +164,7 @@ describe("Basic E2E Operations", () => {
     expect(insertedRecord.name).toBe(uniqueName);
 
     // Get count after insert
-    const newCountResult = await entitySet.list().count().execute();
+    const newCountResult = await entitySet.count().execute();
     assert(newCountResult.data, "Expected data to be defined");
     const newCount = newCountResult.data;
 
@@ -238,7 +238,7 @@ describe("Basic E2E Operations", () => {
     assert(recordId, "Expected PrimaryKey to be defined");
 
     // Get count before delete
-    const beforeCount = await entitySet.list().count().execute();
+    const beforeCount = await entitySet.count().execute();
     assert(beforeCount.data, "Expected count data to be defined");
 
     // Delete the record
@@ -250,7 +250,7 @@ describe("Basic E2E Operations", () => {
     expect(deleteResult.data.deletedCount).toBe(1);
 
     // Verify count decreased
-    const afterCount = await entitySet.list().count().execute();
+    const afterCount = await entitySet.count().execute();
     assert(afterCount.data, "Expected count data to be defined");
     expect(afterCount.data).toBe(beforeCount.data - 1);
   });
@@ -265,7 +265,7 @@ describe("Basic E2E Operations", () => {
     await entitySet.insert({ name: `${marker} - 3` }).execute();
 
     // Get count before delete
-    const beforeCount = await entitySet.list().count().execute();
+    const beforeCount = await entitySet.count().execute();
     assert(beforeCount.data, "Expected count data to be defined");
 
     // Delete all records with the marker
@@ -279,9 +279,21 @@ describe("Basic E2E Operations", () => {
     expect(deleteResult.data.deletedCount).toBeGreaterThanOrEqual(3);
 
     // Verify count decreased
-    const afterCount = await entitySet.list().count().execute();
+    const afterCount = await entitySet.count().execute();
     assert(afterCount.data, "Expected count data to be defined");
     expect(afterCount.data).toBeLessThanOrEqual(beforeCount.data - deleteResult.data.deletedCount);
+  });
+
+  it("should return records and count from list().count()", async () => {
+    const entitySet = db.from(contacts);
+
+    const result = await entitySet.list().top(2).count().execute();
+
+    expect(result.error).toBeUndefined();
+    assert(result.data, "Expected data to be defined");
+    expect(Array.isArray(result.data.records)).toBe(true);
+    expect(result.data.records.length).toBeLessThanOrEqual(2);
+    expect(result.data.count).toBeGreaterThanOrEqual(result.data.records.length);
   });
 
   it("should properly type and validate expanded properties", async () => {

--- a/packages/fmodata/tests/mock.test.ts
+++ b/packages/fmodata/tests/mock.test.ts
@@ -13,7 +13,7 @@
  * 3. The mock fetch will automatically match the request URL to the stored response
  */
 
-import { eq } from "@proofkit/fmodata";
+import { eq, isResponseStructureError } from "@proofkit/fmodata";
 import { MockFMServerConnection } from "@proofkit/fmodata/testing";
 import { assert, describe, expect, expectTypeOf, it } from "vitest";
 import { mockResponses } from "./fixtures/responses";
@@ -69,6 +69,82 @@ describe("Mock Fetch Tests", () => {
       const firstRecord = result.data[0];
       expect(firstRecord).toHaveProperty("@id");
       expect(firstRecord).toHaveProperty("@editLink");
+    });
+
+    it("should return records and count from list().count()", async () => {
+      const mock = new MockFMServerConnection();
+      mock.addRoute({
+        urlPattern: "/fmdapi_test.fmp12/contacts",
+        response: {
+          "@context": "https://api.example.com/fmi/odata/v4/fmdapi_test.fmp12/$metadata#contacts",
+          "@odata.count": "42",
+          value: [
+            {
+              "@id": "contacts('1')",
+              "@editLink": "contacts('1')",
+              PrimaryKey: "1",
+              name: "Alice",
+            },
+          ],
+        },
+        status: 200,
+      });
+      const db = mock.database("fmdapi_test.fmp12");
+
+      const result = await db
+        .from(contacts)
+        .list()
+        .select({ contactName: contacts.name, contactId: contacts.PrimaryKey })
+        .count()
+        .execute();
+
+      expect(result.error).toBeUndefined();
+      expect(result.data).toEqual({
+        count: 42,
+        records: [{ contactId: "1", contactName: "Alice" }],
+      });
+    });
+
+    it("should return a number from top-level count()", async () => {
+      const mock = new MockFMServerConnection({ enableSpy: true });
+      mock.addRoute({
+        urlPattern: "/fmdapi_test.fmp12/contacts/$count",
+        response: "17",
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      });
+      const db = mock.database("fmdapi_test.fmp12");
+
+      const result = await db.from(contacts).count().where(eq(contacts.name, "Alice")).execute();
+
+      expect(result.error).toBeUndefined();
+      expect(result.data).toBe(17);
+      expect(mock.spy?.calls.at(-1)?.url).toContain("/contacts/$count");
+    });
+
+    it("should error when list().count() response is missing @odata.count", async () => {
+      const mock = new MockFMServerConnection();
+      mock.addRoute({
+        urlPattern: "/fmdapi_test.fmp12/contacts",
+        response: {
+          "@context": "https://api.example.com/fmi/odata/v4/fmdapi_test.fmp12/$metadata#contacts",
+          value: [{ PrimaryKey: "1", name: "Alice" }],
+        },
+        status: 200,
+      });
+      const db = mock.database("fmdapi_test.fmp12");
+
+      const result = await db.from(contacts).list().count().execute();
+
+      expect(result.data).toBeUndefined();
+      expect(isResponseStructureError(result.error)).toBe(true);
+    });
+
+    it("should reject single() after list().count()", () => {
+      const mock = new MockFMServerConnection();
+      const db = mock.database("fmdapi_test.fmp12");
+
+      expect(() => (db.from(contacts).list().count() as any).single()).toThrow();
     });
 
     it("should execute a list query with $select using mocked response", async () => {

--- a/packages/fmodata/tests/mock.test.ts
+++ b/packages/fmodata/tests/mock.test.ts
@@ -140,6 +140,24 @@ describe("Mock Fetch Tests", () => {
       expect(isResponseStructureError(result.error)).toBe(true);
     });
 
+    it("should preserve list validation errors before building counted results", async () => {
+      const mock = new MockFMServerConnection();
+      mock.addRoute({
+        urlPattern: "/fmdapi_test.fmp12/contacts",
+        response: {
+          "@context": "https://api.example.com/fmi/odata/v4/fmdapi_test.fmp12/$metadata#contacts",
+          "@odata.count": "1",
+        },
+        status: 200,
+      });
+      const db = mock.database("fmdapi_test.fmp12");
+
+      const result = await db.from(contacts).list().count().execute();
+
+      expect(result.data).toBeUndefined();
+      expect(isResponseStructureError(result.error)).toBe(true);
+    });
+
     it("should reject single() after list().count()", () => {
       const mock = new MockFMServerConnection();
       const db = mock.database("fmdapi_test.fmp12");

--- a/packages/fmodata/tests/query-strings.test.ts
+++ b/packages/fmodata/tests/query-strings.test.ts
@@ -296,16 +296,31 @@ describe("OData Query String Generation", () => {
   });
 
   describe("$count", () => {
-    it("should generate query with $count parameter", () => {
+    it("should generate query with $count parameter for list count", () => {
       const queryString = db.from(users).list().count().getQueryString();
 
       expect(queryString).toContain("$count");
+      expect(queryString).toContain("/users?");
     });
 
-    it("should generate $count with other query parameters", () => {
+    it("should generate $count with other query parameters for list count", () => {
       const queryString = db.from(users).list().where("status eq 'active'").count().getQueryString();
 
       expect(queryString).toContain("$count");
+      expect(queryString).toContain("$filter");
+    });
+
+    it("should generate top-level count path", () => {
+      const queryString = db.from(users).count().getQueryString();
+
+      expect(queryString).toContain("/users/$count");
+      expect(queryString).not.toContain("?$count=true");
+    });
+
+    it("should generate top-level count path with filter", () => {
+      const queryString = db.from(users).count().where("status eq 'active'").getQueryString();
+
+      expect(queryString).toContain("/users/$count");
       expect(queryString).toContain("$filter");
     });
   });

--- a/packages/fmodata/tests/query-strings.test.ts
+++ b/packages/fmodata/tests/query-strings.test.ts
@@ -208,6 +208,14 @@ describe("OData Query String Generation", () => {
     });
   });
 
+  describe("$count", () => {
+    it("should include /$count for navigated top-level count queries", () => {
+      const queryString = db.from(users).navigate(contacts).count().where(eq(contacts.name, "Alice")).getQueryString();
+
+      expect(queryString).toBe(`/users/contacts/$count?$filter=name eq 'Alice'`);
+    });
+  });
+
   describe("$orderby", () => {
     it("should generate $orderby for ascending order", () => {
       const queryString = db.from(users).list().orderBy(asc(users.name)).getQueryString();

--- a/packages/fmodata/tests/typescript.test.ts
+++ b/packages/fmodata/tests/typescript.test.ts
@@ -31,7 +31,7 @@ import {
 import { MockFMServerConnection } from "@proofkit/fmodata/testing";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { z } from "zod/v4";
-import { contacts, users } from "./utils/test-setup";
+import { contacts, type hobbyEnum, users } from "./utils/test-setup";
 
 describe("fmodata", () => {
   describe("API ergonomics", () => {
@@ -44,6 +44,17 @@ describe("fmodata", () => {
 
       expect(listBuilder).toBeDefined();
       expect(listBuilder.getQueryString).toBeDefined();
+    });
+
+    it("should support top-level count() with filters", () => {
+      const table = db.from(contacts);
+      const countBuilder = table.count().where(eq(contacts.name, "Alice"));
+
+      expect(countBuilder).toBeDefined();
+      expect(countBuilder.getQueryString).toBeDefined();
+      expectTypeOf(countBuilder.execute).returns.resolves.toMatchTypeOf<{
+        data: number | undefined;
+      }>();
     });
 
     it("should support get() for single record retrieval", () => {
@@ -76,6 +87,29 @@ describe("fmodata", () => {
 
       expect(singleSelectBuilder).toBeDefined();
       expect(singleSelectBuilder.getQueryString).toBeDefined();
+    });
+
+    it("should infer wrapper type for list().count()", () => {
+      const table = db.from(contacts);
+      const countedBuilder = table.list().select({ name: contacts.name, hobby: contacts.hobby }).count();
+
+      expect(countedBuilder).toBeDefined();
+      expectTypeOf(countedBuilder.execute).returns.resolves.toMatchTypeOf<{
+        data:
+          | {
+              count: number;
+              records: { name: string | null; hobby: z.infer<typeof hobbyEnum> | null }[];
+            }
+          | undefined;
+      }>();
+
+      const _typeChecks = () => {
+        // @ts-expect-error - count-enabled list queries cannot become single queries
+        table.list().count().single();
+        // @ts-expect-error - count-enabled list queries cannot become maybeSingle queries
+        table.list().count().maybeSingle();
+      };
+      _typeChecks;
     });
 
     it("should generate query strings correctly", () => {


### PR DESCRIPTION
## Summary
- Add `db.from(table).count()` as a count-only flow against `/$count`.
- Keep `db.from(table).list().count()` for one-request list plus total count, returning `{ records, count }`.
- Update query typing, URL building, response parsing, tests, docs, and README for the new split.
- Add a minor changeset for `@proofkit/fmodata`.

## Testing
- Not run
- Added/updated package tests for batch, mock, query strings, e2e, and TypeScript behavior.
- Updated docs examples and method reference to match the new API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Count API split: top-level count returns a numeric total; list-based count returns { records, count } to support paginated queries.

* **Documentation**
  * Docs and examples updated to illustrate both count patterns and recommended usage.

* **Tests**
  * Added unit, integration, e2e and type tests covering both count flows, batching, error paths, and compile-time constraints.

* **Chores**
  * Added changeset recording the minor version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->