### PR TITLE
Add Claris ID auth for FileMaker Cloud

### DIFF
--- a/.changeset/early-eels-smile.md
+++ b/.changeset/early-eels-smile.md
@@ -1,0 +1,6 @@
+---
+"@proofkit/fmodata": minor
+"@proofkit/typegen": minor
+---
+
+Add Claris ID auth support for `fmodata` FileMaker Cloud connections, including CLI and typegen env/config support.

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -26,51 +26,34 @@ export default function HomePage() {
       <div className="mx-auto flex w-full max-w-screen-lg flex-col items-center justify-center">
         <div className="relative flex h-[500px] w-full flex-col items-center justify-center overflow-hidden rounded-lg bg-background">
           <InteractiveGridPattern
-            className={cn(
-              "absolute inset-0 [mask-image:radial-gradient(400px_circle_at_center,white,transparent)]",
-            )}
+            className={cn("absolute inset-0 [mask-image:radial-gradient(400px_circle_at_center,white,transparent)]")}
             height={40}
             squares={[80, 80]}
             squaresClassName="hover:fill-brand/50"
             style={{ zIndex: 0 }}
             width={40}
           />
-          <Image
-            alt="ProofKit Logo"
-            className="pointer-events-none z-10"
-            src={ProofKitLogo}
-            width={400}
-          />
+          <Image alt="ProofKit Logo" className="pointer-events-none z-10" src={ProofKitLogo} width={400} />
         </div>
 
         <div className="mt-8 w-full space-y-8 text-center">
-          <h1 className="font-bold text-4xl">
-            A collection of tools for FileMaker-aware TypeScript applications
-          </h1>
+          <h1 className="font-bold text-4xl">A collection of tools for FileMaker-aware TypeScript applications</h1>
           <p className="font-medium text-gray-500 text-xl">
-            For new and experienced developers alike, the ProofKit toolset is
-            the best way to build web apps connected to FileMaker data, or rich,
-            interactive interfaces in a FileMaker webviewer.
+            For new and experienced developers alike, the ProofKit toolset is the best way to build web apps connected
+            to FileMaker data, or rich, interactive interfaces in a FileMaker webviewer.
           </p>
 
           <Cards className="px-4 text-left">
             <Card href="/docs/cli" icon={<Terminal />} title="ProofKit CLI">
-              A command line tool to start a new project, or easily apply
-              templates and common patterns with{" "}
-              <span className="underline">no JavaScript experience</span>{" "}
-              required.
+              A command line tool to start a new project, or easily apply templates and common patterns with{" "}
+              <span className="underline">no JavaScript experience</span> required.
             </Card>
             <Card href="/docs/typegen" icon={<Code />} title={"Typegen"}>
-              Automatically generate runtime validators and TypeScript files
-              from your own FileMaker layouts or table occurrences.
+              Automatically generate runtime validators and TypeScript files from your own FileMaker layouts or table
+              occurrences.
             </Card>
-            <Card
-              href="/docs/fmdapi"
-              icon={<WebhookIcon />}
-              title="Filemaker Data API"
-            >
-              A type-safe API for your FileMaker layouts. Easily connect without
-              worrying about token management.
+            <Card href="/docs/fmdapi" icon={<WebhookIcon />} title="Filemaker Data API">
+              A type-safe API for your FileMaker layouts. Easily connect without worrying about token management.
             </Card>
             <Card
               href="/docs/fmodata"
@@ -84,16 +67,11 @@ export default function HomePage() {
                 </span>
               }
             >
-              A strongly-typed OData API client with full TypeScript inference,
-              runtime validation, and a fluent query builder.
+              A strongly-typed OData API client with full TypeScript inference, runtime validation, and a fluent query
+              builder.
             </Card>
-            <Card
-              href="/docs/webviewer"
-              icon={<Globe />}
-              title="FileMaker Webviewer"
-            >
-              Use async functions in WebViewer code to execute and get the
-              result of a FileMaker script.
+            <Card href="/docs/webviewer" icon={<Globe />} title="FileMaker Webviewer">
+              Use async functions in WebViewer code to execute and get the result of a FileMaker script.
             </Card>
             <Card
               href="/docs/better-auth"
@@ -107,8 +85,7 @@ export default function HomePage() {
                 </span>
               }
             >
-              Own your authentication with FileMaker and the extensible
-              Better-Auth framework.
+              Own your authentication with FileMaker and the extensible Better-Auth framework.
             </Card>
           </Cards>
 
@@ -118,8 +95,7 @@ export default function HomePage() {
             <div className="flex flex-col text-left">
               <h2 className="mb-4 font-bold text-3xl">Quick Start</h2>
               <p className="mb-0 text-gray-600 text-lg">
-                Use the ProofKit CLI to launch a full-featured Next.js app in
-                minutes—no prior experience required.
+                Use the ProofKit CLI to launch a full-featured Next.js app in minutes—no prior experience required.
               </p>
             </div>
 
@@ -152,11 +128,9 @@ export default function HomePage() {
                 Built for AI Agents
               </h2>
               <p className="mb-0 text-gray-600 text-lg">
-                Every ProofKit package ships with agent skills — built from
-                decades of combined FileMaker integration experience at Proof —
-                that give AI coding tools like Claude Code and Cursor the
-                context they need to write correct, production-ready FileMaker
-                code from day one.
+                Every ProofKit package ships with agent skills — built from decades of combined FileMaker integration
+                experience at Proof — that give AI coding tools like Claude Code and Cursor the context they need to
+                write correct, production-ready FileMaker code from day one.
               </p>
             </div>
 
@@ -167,9 +141,8 @@ export default function HomePage() {
                   Expert knowledge built in
                 </div>
                 <p className="text-gray-500 text-sm">
-                  Agent skills cover API patterns, edge cases, and common
-                  mistakes so your AI agent avoids the pitfalls that trip up
-                  even experienced developers.
+                  Agent skills cover API patterns, edge cases, and common mistakes so your AI agent avoids the pitfalls
+                  that trip up even experienced developers.
                 </p>
               </div>
               <div className="flex flex-col gap-2 rounded-lg border p-4">
@@ -178,9 +151,8 @@ export default function HomePage() {
                   Type-safe by default
                 </div>
                 <p className="text-gray-500 text-sm">
-                  Schemas generated from your FileMaker field names plus runtime
-                  validators catch bugs early — whether code is written by you
-                  or your AI agent.
+                  Schemas generated from your FileMaker field names plus runtime validators catch bugs early — whether
+                  code is written by you or your AI agent.
                 </p>
               </div>
               <div className="flex flex-col gap-2 rounded-lg border p-4">
@@ -189,9 +161,8 @@ export default function HomePage() {
                   Works with any agent
                 </div>
                 <p className="text-gray-500 text-sm">
-                  Skills are bundled with each package — just install and your
-                  AI coding tool picks them up automatically. Compatible with
-                  Claude Code, Cursor, Windsurf, and more.
+                  Skills are bundled with each package — just install and your AI coding tool picks them up
+                  automatically. Compatible with Claude Code, Cursor, Windsurf, and more.
                 </p>
               </div>
             </div>

--- a/apps/docs/src/app/docs/(docs)/layout.tsx
+++ b/apps/docs/src/app/docs/(docs)/layout.tsx
@@ -16,12 +16,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <div className="mt-2 flex items-center justify-center text-muted-foreground text-xs">
             <p>
               Made with ❤️ by{" "}
-              <a
-                className="underline"
-                href="http://proof.sh"
-                rel="noopener"
-                target="_blank"
-              >
+              <a className="underline" href="http://proof.sh" rel="noopener" target="_blank">
                 Proof
               </a>
             </p>

--- a/apps/docs/src/app/docs/templates/layout.tsx
+++ b/apps/docs/src/app/docs/templates/layout.tsx
@@ -86,12 +86,7 @@ export default async function Layout({ children }: { children: ReactNode }) {
           <div className="mt-2 flex items-center justify-center text-muted-foreground text-xs">
             <p>
               Made with ❤️ by{" "}
-              <a
-                className="underline"
-                href="http://proof.sh"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
+              <a className="underline" href="http://proof.sh" rel="noopener noreferrer" target="_blank">
                 Proof
               </a>
             </p>

--- a/packages/fmodata/README.md
+++ b/packages/fmodata/README.md
@@ -40,6 +40,12 @@ const connection = new FMServerConnection({
     // OttoFMS API key
     apiKey: "your-api-key",
 
+    // or Claris ID for FileMaker Cloud
+    // clarisId: {
+    //   username: "your@claris-id.com",
+    //   password: "password",
+    // },
+
     // or username and password
     // username: "admin",
     // password: "password",
@@ -96,7 +102,7 @@ OData relies entirely on the table occurances in the relationship graph for data
 
 ### Server Connection
 
-The client can authenticate using username/password or API key:
+The client can authenticate using username/password, Otto API key, or Claris ID for FileMaker Cloud:
 
 ```typescript
 // Username and password authentication
@@ -115,7 +121,25 @@ const connection = new FMServerConnection({
     apiKey: "your-api-key",
   },
 });
+
+// Claris ID authentication for FileMaker Cloud
+const connection = new FMServerConnection({
+  serverUrl: "https://your-filemaker-cloud-host.com",
+  auth: {
+    clarisId: {
+      username: "your@claris-id.com",
+      password: "password",
+    },
+  },
+});
 ```
+
+Notes for Claris ID auth:
+
+- Use a Claris ID account, not an external IdP account.
+- Tokens are managed internally and refreshed automatically.
+- Claris ID tokens are valid for about one hour.
+- MFA is not supported.
 
 ### Schema Definitions
 

--- a/packages/fmodata/package.json
+++ b/packages/fmodata/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@fetchkit/ffetch": "^4.2.0",
+    "amazon-cognito-identity-js": "^6.3.16",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.2",
     "dotenv": "^16.6.1",

--- a/packages/fmodata/skills/fmodata-client/SKILL.md
+++ b/packages/fmodata/skills/fmodata-client/SKILL.md
@@ -33,12 +33,16 @@ const connection = new FMServerConnection({
   auth: { username: "admin", password: "secret" },
   // OR with OttoFMS API key:
   // auth: { apiKey: "your-otto-api-key" },
+  // OR with Claris ID for FileMaker Cloud:
+  // auth: { clarisId: { username: "you@claris-id.com", password: "secret" } },
   fetchClientOptions: {
     retries: 2,
     timeout: 30000,
   },
 });
 ```
+
+For FileMaker Cloud, use a Claris ID account, not an external IdP account. MFA-backed Claris ID accounts are not supported.
 
 ### 2. Create a database reference
 

--- a/packages/fmodata/src/cli/index.ts
+++ b/packages/fmodata/src/cli/index.ts
@@ -21,6 +21,8 @@ program
   .option("--database <name>", `FM database name [env: ${ENV_NAMES.db}]`)
   .option("--username <user>", `FM username [env: ${ENV_NAMES.username}]`)
   .option("--password <pass>", `FM password [env: ${ENV_NAMES.password}]`)
+  .option("--claris-id-username <user>", `Claris ID username [env: ${ENV_NAMES.clarisIdUsername}]`)
+  .option("--claris-id-password <pass>", `Claris ID password [env: ${ENV_NAMES.clarisIdPassword}]`)
   .option("--api-key <key>", `OttoFMS API key [env: ${ENV_NAMES.apiKey}]`)
   .option("--pretty", "Output as table (default: JSON)", false);
 

--- a/packages/fmodata/src/cli/utils/connection.ts
+++ b/packages/fmodata/src/cli/utils/connection.ts
@@ -6,6 +6,8 @@ export const ENV_NAMES = {
   db: "FM_DATABASE",
   username: "FM_USERNAME",
   password: "FM_PASSWORD",
+  clarisIdUsername: "CLARIS_ID_USERNAME",
+  clarisIdPassword: "CLARIS_ID_PASSWORD",
   apiKey: "OTTO_API_KEY",
 } as const;
 
@@ -14,6 +16,8 @@ export interface ConnectionOptions {
   database?: string;
   username?: string;
   password?: string;
+  clarisIdUsername?: string;
+  clarisIdPassword?: string;
   apiKey?: string;
 }
 
@@ -28,6 +32,8 @@ export function buildConnection(opts: ConnectionOptions): BuiltConnection {
   const apiKey = opts.apiKey ?? process.env[ENV_NAMES.apiKey];
   const username = opts.username ?? process.env[ENV_NAMES.username];
   const password = opts.password ?? process.env[ENV_NAMES.password];
+  const clarisIdUsername = opts.clarisIdUsername ?? process.env[ENV_NAMES.clarisIdUsername];
+  const clarisIdPassword = opts.clarisIdPassword ?? process.env[ENV_NAMES.clarisIdPassword];
 
   if (!server) {
     throw new Error(`Missing required: --server or ${ENV_NAMES.server} environment variable`);
@@ -35,14 +41,34 @@ export function buildConnection(opts: ConnectionOptions): BuiltConnection {
   if (!database) {
     throw new Error(`Missing required: --database or ${ENV_NAMES.db} environment variable`);
   }
-  if (!(apiKey || username)) {
-    throw new Error(`Missing required auth: --api-key (${ENV_NAMES.apiKey}) or --username (${ENV_NAMES.username})`);
+  if (!(apiKey || clarisIdUsername || username)) {
+    throw new Error(
+      `Missing required auth: --api-key (${ENV_NAMES.apiKey}), --claris-id-username (${ENV_NAMES.clarisIdUsername}), or --username (${ENV_NAMES.username})`,
+    );
+  }
+  if (!apiKey && clarisIdUsername && !clarisIdPassword) {
+    throw new Error(`Missing required: --claris-id-password (${ENV_NAMES.clarisIdPassword}) when using Claris ID auth`);
   }
   if (!apiKey && username && !password) {
     throw new Error(`Missing required: --password (${ENV_NAMES.password}) when using username auth`);
   }
 
-  const auth = apiKey ? { apiKey } : { username: username as string, password: password as string };
+  let auth:
+    | { apiKey: string }
+    | { clarisId: { username: string; password: string } }
+    | { username: string; password: string };
+  if (apiKey) {
+    auth = { apiKey };
+  } else if (clarisIdUsername) {
+    auth = {
+      clarisId: {
+        username: clarisIdUsername as string,
+        password: clarisIdPassword as string,
+      },
+    };
+  } else {
+    auth = { username: username as string, password: password as string };
+  }
   const connection = new FMServerConnection({ serverUrl: server, auth });
   const db = connection.database(database);
   return { connection, db };

--- a/packages/fmodata/src/client/amazon-cognito-identity-js.d.ts
+++ b/packages/fmodata/src/client/amazon-cognito-identity-js.d.ts
@@ -1,0 +1,55 @@
+declare module "amazon-cognito-identity-js" {
+  export class CognitoRefreshToken {
+    constructor(data: { RefreshToken: string });
+  }
+
+  export class CognitoAccessToken {
+    constructor(data: { AccessToken: string });
+    getJwtToken(): string;
+  }
+
+  export class CognitoIdToken {
+    constructor(data: { IdToken: string });
+    getJwtToken(): string;
+  }
+
+  export class CognitoUserSession {
+    constructor(data: {
+      AccessToken: CognitoAccessToken;
+      IdToken: CognitoIdToken;
+      RefreshToken: CognitoRefreshToken;
+    });
+    isValid(): boolean;
+    getIdToken(): CognitoIdToken;
+    getAccessToken(): CognitoAccessToken;
+    getRefreshToken(): CognitoRefreshToken;
+  }
+
+  export class AuthenticationDetails {
+    constructor(data: { Username: string; Password: string });
+    getUsername(): string;
+  }
+
+  export class CognitoUserPool {
+    constructor(data: { UserPoolId: string; ClientId: string });
+  }
+
+  export class CognitoUser {
+    constructor(data: { Username: string; Pool: CognitoUserPool });
+    authenticateUser(
+      details: AuthenticationDetails,
+      callbacks: {
+        onSuccess: (session: CognitoUserSession) => void;
+        onFailure: (error: unknown) => void;
+        mfaRequired?: (...args: unknown[]) => void;
+        totpRequired?: (...args: unknown[]) => void;
+        selectMFAType?: (...args: unknown[]) => void;
+        mfaSetup?: (...args: unknown[]) => void;
+      },
+    ): void;
+    refreshSession(
+      refreshToken: CognitoRefreshToken,
+      callback: (error: unknown, session: CognitoUserSession | null) => void,
+    ): void;
+  }
+}

--- a/packages/fmodata/src/client/claris-id.ts
+++ b/packages/fmodata/src/client/claris-id.ts
@@ -1,0 +1,153 @@
+/// <reference path="./amazon-cognito-identity-js.d.ts" />
+
+import type { CognitoUserSession } from "amazon-cognito-identity-js";
+import { AuthenticationDetails, CognitoUser, CognitoUserPool } from "amazon-cognito-identity-js";
+
+const CLARIS_USER_POOL_URL = "https://www.ifmcloud.com/endpoint/userpool/2.2.0.my.claris.com.json";
+const UNSUPPORTED_MFA_ERROR =
+  "Claris ID MFA is not supported by @proofkit/fmodata yet. Use a non-MFA Claris ID account for now.";
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+interface UserPoolConfigResponse {
+  data?: {
+    UserPool_ID?: string;
+    Client_ID?: string;
+  };
+}
+
+export class ClarisIdAuthManager {
+  private readonly username: string;
+  private readonly password: string;
+  private authenticationDetails: AuthenticationDetails | undefined;
+  private userPool: CognitoUserPool | null = null;
+  private cognitoUser: CognitoUser | null = null;
+  private userSession: CognitoUserSession | null = null;
+  private idTokenPromise: Promise<string> | null = null;
+
+  constructor(config: { username: string; password: string }) {
+    this.username = config.username;
+    this.password = config.password;
+  }
+
+  async getAuthorizationHeader(fetchLike?: FetchLike): Promise<string> {
+    if (!this.idTokenPromise) {
+      this.idTokenPromise = this.getIdToken(fetchLike).finally(() => {
+        this.idTokenPromise = null;
+      });
+    }
+
+    return `FMID ${await this.idTokenPromise}`;
+  }
+
+  private getAuthenticationDetails(): AuthenticationDetails {
+    if (!this.authenticationDetails) {
+      this.authenticationDetails = new AuthenticationDetails({
+        Username: this.username,
+        Password: this.password,
+      });
+    }
+
+    return this.authenticationDetails;
+  }
+
+  private async getIdToken(fetchLike?: FetchLike): Promise<string> {
+    if (this.userSession) {
+      return this.getStoredIdToken(this.userSession);
+    }
+
+    const userSession = await this.retrieveNewSession(fetchLike);
+    return userSession.getIdToken().getJwtToken();
+  }
+
+  private async getStoredIdToken(userSession: CognitoUserSession): Promise<string> {
+    const currentUserSession = userSession.isValid() ? userSession : await this.refreshSession(userSession);
+    return currentUserSession.getIdToken().getJwtToken();
+  }
+
+  private async refreshSession(userSession: CognitoUserSession): Promise<CognitoUserSession> {
+    const cognitoUser = await this.getCognitoUser();
+
+    this.userSession = await new Promise<CognitoUserSession>((resolve, reject) => {
+      cognitoUser.refreshSession(
+        userSession.getRefreshToken(),
+        async (error: unknown, session: CognitoUserSession | null) => {
+          if (error || !session) {
+            try {
+              resolve(await this.retrieveNewSession());
+              return;
+            } catch (reauthError) {
+              reject(reauthError);
+              return;
+            }
+          }
+
+          resolve(session);
+        },
+      );
+    });
+
+    return this.userSession;
+  }
+
+  private async retrieveNewSession(fetchLike?: FetchLike): Promise<CognitoUserSession> {
+    const cognitoUser = await this.getCognitoUser(fetchLike);
+    const authenticationDetails = this.getAuthenticationDetails();
+
+    this.userSession = await new Promise<CognitoUserSession>((resolve, reject) => {
+      cognitoUser.authenticateUser(authenticationDetails, {
+        onSuccess: (result: CognitoUserSession) => {
+          resolve(result);
+        },
+        onFailure: (error: unknown) => {
+          reject(error);
+        },
+        mfaRequired: () => reject(new Error(UNSUPPORTED_MFA_ERROR)),
+        totpRequired: () => reject(new Error(UNSUPPORTED_MFA_ERROR)),
+        selectMFAType: () => reject(new Error(UNSUPPORTED_MFA_ERROR)),
+        mfaSetup: () => reject(new Error(UNSUPPORTED_MFA_ERROR)),
+      });
+    });
+
+    return this.userSession;
+  }
+
+  private async getCognitoUser(fetchLike?: FetchLike): Promise<CognitoUser> {
+    if (this.cognitoUser) {
+      return this.cognitoUser;
+    }
+
+    this.cognitoUser = new CognitoUser({
+      Username: this.getAuthenticationDetails().getUsername(),
+      Pool: await this.getUserPool(fetchLike),
+    });
+
+    return this.cognitoUser;
+  }
+
+  private async getUserPool(fetchLike?: FetchLike): Promise<CognitoUserPool> {
+    if (this.userPool) {
+      return this.userPool;
+    }
+
+    const response = await (fetchLike ?? fetch)(CLARIS_USER_POOL_URL);
+    if (!response.ok) {
+      throw new Error("Could not fetch Claris ID user pool config");
+    }
+
+    const config = (await response.json()) as UserPoolConfigResponse;
+    const userPoolId = config.data?.UserPool_ID;
+    const clientId = config.data?.Client_ID;
+
+    if (!(userPoolId && clientId)) {
+      throw new Error("Invalid Claris ID user pool config response");
+    }
+
+    this.userPool = new CognitoUserPool({
+      UserPoolId: userPoolId,
+      ClientId: clientId,
+    });
+
+    return this.userPool;
+  }
+}

--- a/packages/fmodata/src/client/filemaker-odata.ts
+++ b/packages/fmodata/src/client/filemaker-odata.ts
@@ -15,6 +15,7 @@ import { createLogger, type InternalLogger, type Logger } from "../logger";
 import { type FMODataLayer, HttpClient, ODataConfig, ODataLogger } from "../services";
 import type { Auth, ExecutionContext, Result } from "../types";
 import { getAcceptHeader } from "../types";
+import { ClarisIdAuthManager } from "./claris-id";
 import { Database } from "./database";
 import { safeJsonParse } from "./sanitize-json";
 
@@ -27,6 +28,7 @@ export class FMServerConnection implements ExecutionContext {
   private useEntityIds = false;
   private includeSpecialColumns = false;
   private readonly logger: InternalLogger;
+  private readonly clarisIdAuthManager: ClarisIdAuthManager | null;
   /** @internal Stored so credential-override flows can inherit non-auth config. */
   readonly _fetchClientOptions: FFetchOptions | undefined;
   constructor(config: {
@@ -50,6 +52,13 @@ export class FMServerConnection implements ExecutionContext {
     url.pathname = url.pathname.replace(TRAILING_SLASH_REGEX, "");
     this.serverUrl = url.toString().replace(TRAILING_SLASH_REGEX, "");
     this.auth = config.auth;
+    this.clarisIdAuthManager =
+      "clarisId" in config.auth
+        ? new ClarisIdAuthManager({
+            username: config.auth.clarisId.username,
+            password: config.auth.clarisId.password,
+          })
+        : null;
   }
 
   /**
@@ -90,6 +99,21 @@ export class FMServerConnection implements ExecutionContext {
    */
   _getBaseUrl(): string {
     return `${this.serverUrl}${"apiKey" in this.auth ? "/otto" : ""}/fmi/odata/v4`;
+  }
+
+  private _getAuthorizationHeader(fetchHandler?: typeof fetch): Promise<string> {
+    if ("apiKey" in this.auth) {
+      return Promise.resolve(`Bearer ${this.auth.apiKey}`);
+    }
+
+    if ("clarisId" in this.auth) {
+      if (!this.clarisIdAuthManager) {
+        throw new Error("Claris ID auth manager was not initialized");
+      }
+      return this.clarisIdAuthManager.getAuthorizationHeader(fetchHandler);
+    }
+
+    return Promise.resolve(`Basic ${btoa(`${this.auth.username}:${this.auth.password}`)}`);
   }
 
   /**
@@ -219,46 +243,43 @@ export class FMServerConnection implements ExecutionContext {
       preferValues.push("fmodata.include-specialcolumns");
     }
 
-    const headers = {
-      Authorization:
-        "apiKey" in this.auth
-          ? `Bearer ${this.auth.apiKey}`
-          : `Basic ${btoa(`${this.auth.username}:${this.auth.password}`)}`,
+    const buildHeaders = async () => ({
+      Authorization: await this._getAuthorizationHeader(fetchHandler),
       "Content-Type": "application/json",
       Accept: getAcceptHeader(includeODataAnnotations),
       ...(preferValues.length > 0 ? { Prefer: preferValues.join(", ") } : {}),
       ...(options?.headers || {}),
-    };
-
-    // Prepare loggableHeaders by omitting the Authorization key
-    const { Authorization, ...loggableHeaders } = headers;
-    logger.debug("Request headers:", loggableHeaders);
+    });
 
     // TEMPORARY WORKAROUND: Hopefully this feature will be fixed in the ffetch library
     // Extract fetchHandler and headers separately, only for tests where we're overriding the fetch handler per-request
-    const fetchHandler = options?.fetchHandler;
+    const fetchHandler = options?.fetchHandler ?? this._fetchClientOptions?.fetchHandler;
     const { headers: _headers, fetchHandler: _fetchHandler, ...restOptions } = options || {};
 
     // If fetchHandler is provided, create a temporary client with it
     // Otherwise use the existing client
     const clientToUse = fetchHandler ? createClient({ retries: 0, fetchHandler }) : this.fetchClient;
 
-    const finalOptions = {
-      ...restOptions,
-      headers,
-    };
-
     // Step 1: Execute the HTTP request
     const fetchEffect = Effect.tryPromise({
-      try: () => clientToUse(fullUrl, finalOptions),
+      try: async () => {
+        const headers = await buildHeaders();
+        const { Authorization, ...loggableHeaders } = headers;
+        logger.debug("Request headers:", loggableHeaders);
+
+        const finalOptions = {
+          ...restOptions,
+          headers,
+        };
+
+        return clientToUse(fullUrl, finalOptions);
+      },
       catch: (err) => this._classifyError(err, fullUrl),
     });
 
     // Step 2: Process the response
     const pipeline = fetchEffect.pipe(
-      Effect.tap((resp) =>
-        Effect.sync(() => logger.debug(`${finalOptions.method ?? "GET"} ${resp.status} ${fullUrl}`)),
-      ),
+      Effect.tap((resp) => Effect.sync(() => logger.debug(`${restOptions.method ?? "GET"} ${resp.status} ${fullUrl}`))),
       Effect.flatMap((resp) => {
         // Handle HTTP errors
         if (!resp.ok) {
@@ -319,7 +340,7 @@ export class FMServerConnection implements ExecutionContext {
 
     // biome-ignore lint/suspicious/noExplicitAny: Type assertion for optional property access
     const retryPolicy = (options as any)?.retryPolicy;
-    const method = (finalOptions.method ?? "GET").toUpperCase();
+    const method = (restOptions.method ?? "GET").toUpperCase();
     const isRetrySafeMethod = method === "GET" || method === "HEAD" || method === "OPTIONS" || method === "PUT";
 
     const requestEffect = retryPolicy && isRetrySafeMethod ? withRetryPolicy(pipeline, retryPolicy) : pipeline;

--- a/packages/fmodata/src/types.ts
+++ b/packages/fmodata/src/types.ts
@@ -1,7 +1,23 @@
 import type { FFetchOptions } from "@fetchkit/ffetch";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
-export type Auth = { username: string; password: string } | { apiKey: string };
+export interface BasicAuth {
+  username: string;
+  password: string;
+}
+
+export interface ApiKeyAuth {
+  apiKey: string;
+}
+
+export interface ClarisIdAuth {
+  clarisId: {
+    username: string;
+    password: string;
+  };
+}
+
+export type Auth = BasicAuth | ApiKeyAuth | ClarisIdAuth;
 
 export interface ExecutableBuilder<T> {
   execute(): Promise<Result<T>>;

--- a/packages/fmodata/tests/claris-id.test.ts
+++ b/packages/fmodata/tests/claris-id.test.ts
@@ -1,0 +1,182 @@
+import {
+  CognitoAccessToken,
+  CognitoIdToken,
+  CognitoRefreshToken,
+  CognitoUser,
+  CognitoUserSession,
+} from "amazon-cognito-identity-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClarisIdAuthManager } from "../src/client/claris-id";
+import { FMServerConnection } from "../src/client/filemaker-odata";
+
+const USER_POOL_CONFIG_RE = /user pool config/i;
+const MFA_UNSUPPORTED_RE = /MFA is not supported/i;
+
+function makeJwt(expOffsetSeconds: number) {
+  const encode = (value: object) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "HS256", typ: "JWT" })}.${encode({
+    exp: Math.floor(Date.now() / 1000) + expOffsetSeconds,
+    iat: Math.floor(Date.now() / 1000) - 60,
+  })}.sig`;
+}
+
+function makeSession(expOffsetSeconds: number) {
+  return new CognitoUserSession({
+    AccessToken: new CognitoAccessToken({ AccessToken: makeJwt(expOffsetSeconds) }),
+    IdToken: new CognitoIdToken({ IdToken: makeJwt(expOffsetSeconds) }),
+    RefreshToken: new CognitoRefreshToken({ RefreshToken: "refresh-token" }),
+  });
+}
+
+const validSession = makeSession(3600);
+const expiredSession = makeSession(-3600);
+
+describe("ClarisIdAuthManager", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              data: {
+                UserPool_ID: "us-west-2_NqkuZcXQY",
+                Client_ID: "4l9rvl4mv5es1eep1qe97cautn",
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns FMID header on successful auth", async () => {
+    vi.spyOn(CognitoUser.prototype, "authenticateUser").mockImplementation((_details, callbacks: any) => {
+      callbacks.onSuccess(validSession);
+    });
+
+    const manager = new ClarisIdAuthManager({ username: "user", password: "pass" });
+    await expect(manager.getAuthorizationHeader()).resolves.toBe(`FMID ${validSession.getIdToken().getJwtToken()}`);
+  });
+
+  it("reuses cached valid token across sequential calls", async () => {
+    const authenticateSpy = vi
+      .spyOn(CognitoUser.prototype, "authenticateUser")
+      .mockImplementation((_details, callbacks: any) => {
+        callbacks.onSuccess(validSession);
+      });
+
+    const manager = new ClarisIdAuthManager({ username: "user", password: "pass" });
+    await manager.getAuthorizationHeader();
+    await manager.getAuthorizationHeader();
+
+    expect(authenticateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes parallel auth calls", async () => {
+    const authenticateSpy = vi
+      .spyOn(CognitoUser.prototype, "authenticateUser")
+      .mockImplementation((_details, callbacks: any) => {
+        setTimeout(() => callbacks.onSuccess(validSession), 0);
+      });
+
+    const manager = new ClarisIdAuthManager({ username: "user", password: "pass" });
+    await Promise.all([manager.getAuthorizationHeader(), manager.getAuthorizationHeader()]);
+
+    expect(authenticateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes an expired token", async () => {
+    const authenticateSpy = vi
+      .spyOn(CognitoUser.prototype, "authenticateUser")
+      .mockImplementation((_details, callbacks: any) => {
+        callbacks.onSuccess(expiredSession);
+      });
+    const refreshSpy = vi.spyOn(CognitoUser.prototype, "refreshSession").mockImplementation((_token, callback: any) => {
+      callback(null, validSession);
+    });
+
+    const manager = new ClarisIdAuthManager({ username: "user", password: "pass" });
+    await manager.getAuthorizationHeader();
+    await expect(manager.getAuthorizationHeader()).resolves.toBe(`FMID ${validSession.getIdToken().getJwtToken()}`);
+
+    expect(authenticateSpy).toHaveBeenCalledTimes(1);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to full re-auth when refresh fails", async () => {
+    const authenticateSpy = vi
+      .spyOn(CognitoUser.prototype, "authenticateUser")
+      .mockImplementationOnce((_details, callbacks: any) => {
+        callbacks.onSuccess(expiredSession);
+      })
+      .mockImplementationOnce((_details, callbacks: any) => {
+        callbacks.onSuccess(validSession);
+      });
+    vi.spyOn(CognitoUser.prototype, "refreshSession").mockImplementation((_token, callback: any) => {
+      callback(new Error("refresh failed"));
+    });
+
+    const manager = new ClarisIdAuthManager({ username: "user", password: "pass" });
+    await manager.getAuthorizationHeader();
+    await expect(manager.getAuthorizationHeader()).resolves.toBe(`FMID ${validSession.getIdToken().getJwtToken()}`);
+
+    expect(authenticateSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when user pool config fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 500, headers: { "content-type": "text/plain" } })),
+    );
+
+    vi.spyOn(CognitoUser.prototype, "authenticateUser").mockImplementation((_details, callbacks: any) => {
+      callbacks.onSuccess(validSession);
+    });
+
+    const manager = new ClarisIdAuthManager({ username: "user", password: "pass" });
+    await expect(manager.getAuthorizationHeader()).rejects.toThrow(USER_POOL_CONFIG_RE);
+  });
+
+  it("throws clear error for MFA challenge", async () => {
+    vi.spyOn(CognitoUser.prototype, "authenticateUser").mockImplementation((_details, callbacks: any) => {
+      callbacks.mfaRequired?.();
+    });
+
+    const manager = new ClarisIdAuthManager({ username: "user", password: "pass" });
+    await expect(manager.getAuthorizationHeader()).rejects.toThrow(MFA_UNSUPPORTED_RE);
+  });
+});
+
+describe("FMServerConnection Claris ID integration", () => {
+  it("sends FMID authorization header", async () => {
+    vi.spyOn(ClarisIdAuthManager.prototype, "getAuthorizationHeader").mockResolvedValue("FMID test-token");
+
+    let authorizationHeader = "";
+    const fetchHandler: typeof fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      authorizationHeader = request.headers.get("authorization") ?? "";
+
+      return Promise.resolve(
+        new Response(JSON.stringify({ value: [{ name: "contacts" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    };
+
+    const connection = new FMServerConnection({
+      serverUrl: "https://example.com",
+      auth: { clarisId: { username: "user", password: "pass" } },
+      fetchClientOptions: { fetchHandler },
+    });
+
+    await connection.database("TestDB").listTableNames();
+    expect(authorizationHeader).toBe("FMID test-token");
+  });
+});

--- a/packages/fmodata/tests/cli/unit/connection.test.ts
+++ b/packages/fmodata/tests/cli/unit/connection.test.ts
@@ -38,6 +38,17 @@ describe("buildConnection", () => {
     expect(db).toBeDefined();
   });
 
+  it("builds a connection from env vars with Claris ID auth", () => {
+    process.env[ENV_NAMES.server] = "https://example.com";
+    process.env[ENV_NAMES.db] = "MyDB.fmp12";
+    process.env[ENV_NAMES.clarisIdUsername] = "claris-user";
+    process.env[ENV_NAMES.clarisIdPassword] = "claris-pass";
+
+    const { connection, db } = buildConnection({});
+    expect(connection).toBeDefined();
+    expect(db).toBeDefined();
+  });
+
   it("CLI options override env vars", () => {
     process.env[ENV_NAMES.server] = "https://env-server.com";
     process.env[ENV_NAMES.db] = "EnvDB.fmp12";
@@ -86,11 +97,32 @@ describe("buildConnection", () => {
     expect(() => buildConnection({})).toThrow(PASSWORD_RE);
   });
 
+  it("throws when Claris ID username is set but password is missing", () => {
+    process.env[ENV_NAMES.server] = "https://example.com";
+    process.env[ENV_NAMES.db] = "MyDB.fmp12";
+    process.env[ENV_NAMES.clarisIdUsername] = "claris-user";
+    delete process.env[ENV_NAMES.clarisIdPassword];
+
+    expect(() => buildConnection({})).toThrow(PASSWORD_RE);
+  });
+
   it("prefers api key over username auth when both are set", () => {
     const { db } = buildConnection({
       server: "https://example.com",
       database: "MyDB.fmp12",
       apiKey: "api-key",
+      username: "admin",
+      password: "secret",
+    });
+    expect(db).toBeDefined();
+  });
+
+  it("prefers Claris ID over username auth when both are set", () => {
+    const { db } = buildConnection({
+      server: "https://example.com",
+      database: "MyDB.fmp12",
+      clarisIdUsername: "claris-user",
+      clarisIdPassword: "claris-pass",
       username: "admin",
       password: "secret",
     });

--- a/packages/typegen/README.md
+++ b/packages/typegen/README.md
@@ -25,11 +25,19 @@ const args: BuildSchemaArgs = {
   envNames: {
     server: "FM_SERVER",
     db: "FM_DATABASE",
-    auth: { apiKey: "OTTO_API_KEY", username: undefined, password: undefined },
+    auth: {
+      apiKey: "OTTO_API_KEY",
+      clarisIdUsername: "CLARIS_ID_USERNAME",
+      clarisIdPassword: "CLARIS_ID_PASSWORD",
+      username: undefined,
+      password: undefined,
+    },
   },
 };
 
 buildSchema(file, args);
 ```
+
+For `fmodata` configs targeting FileMaker Cloud, `envNames.auth` also supports `clarisIdUsername` and `clarisIdPassword`. These map to Claris ID credentials used for OData auth. MFA-backed Claris ID accounts are not supported yet.
 
 Check out the full documentation at [proofkit.dev](https://proofkit.dev/docs/typegen).

--- a/packages/typegen/src/constants.ts
+++ b/packages/typegen/src/constants.ts
@@ -27,6 +27,8 @@ export const defaultEnvNames = {
   ottoPort: "OTTO_PORT",
   username: "FM_USERNAME",
   password: "FM_PASSWORD",
+  clarisIdUsername: "CLARIS_ID_USERNAME",
+  clarisIdPassword: "CLARIS_ID_PASSWORD",
   server: "FM_SERVER",
   db: "FM_DATABASE",
   fmMcpBaseUrl: "FM_MCP_BASE_URL",

--- a/packages/typegen/src/fmodata/downloadMetadata.ts
+++ b/packages/typegen/src/fmodata/downloadMetadata.ts
@@ -22,7 +22,7 @@ export async function downloadTableMetadata({
   reduceAnnotations?: boolean;
 }): Promise<string> {
   const envValues = getEnvValues(config.envNames);
-  const validationResult = validateEnvValues(envValues, config.envNames);
+  const validationResult = validateEnvValues(envValues, config.envNames, { allowClarisId: true });
 
   if (!validationResult.success) {
     throw new Error(validationResult.errorMessage);

--- a/packages/typegen/src/getEnvValues.ts
+++ b/packages/typegen/src/getEnvValues.ts
@@ -9,11 +9,18 @@ export interface EnvValues {
   server: string | undefined;
   db: string | undefined;
   apiKey: string | undefined;
+  clarisIdUsername: string | undefined;
+  clarisIdPassword: string | undefined;
   username: string | undefined;
   password: string | undefined;
   fmMcpBaseUrl: string | undefined;
   fmMcpConnectedFileName: string | undefined;
 }
+
+type StandardAuth =
+  | { apiKey: string }
+  | { username: string; password: string }
+  | { clarisId: { username: string; password: string } };
 
 export type EnvValidationResult =
   | {
@@ -21,7 +28,7 @@ export type EnvValidationResult =
       mode: "standard";
       server: string;
       db: string;
-      auth: { apiKey: string } | { username: string; password: string };
+      auth: StandardAuth;
     }
   | {
       success: true;
@@ -34,6 +41,12 @@ export type EnvValidationResult =
       errorMessage: string;
     };
 
+interface EnvValidationOptions {
+  fmMcp?: boolean;
+  allowClarisId?: boolean;
+  fmMcpConfig?: { baseUrl?: string; connectedFileName?: string };
+}
+
 /**
  * Gets environment variable values for FileMaker connection.
  * Supports both fmdapi and fmodata config types.
@@ -42,21 +55,24 @@ export type EnvValidationResult =
  * @returns Object containing all environment variable values
  */
 export function getEnvValues(envNames?: EnvNames): EnvValues {
-  // Helper to get env name, treating empty strings as undefined
   const getEnvName = (customName: string | undefined, defaultName: string) =>
     customName && customName.trim() !== "" ? customName : defaultName;
 
-  // Resolve environment variables
   const server = process.env[getEnvName(envNames?.server, defaultEnvNames.server)];
   const db = process.env[getEnvName(envNames?.db, defaultEnvNames.db)];
 
-  // Always attempt to read all auth methods from environment variables,
-  // regardless of which type is specified in envNames.auth
-  // This matches the pattern in getEnvVarsFromConfig
   const apiKeyEnvName =
     envNames?.auth && "apiKey" in envNames.auth
       ? getEnvName(envNames.auth.apiKey, defaultEnvNames.apiKey)
       : defaultEnvNames.apiKey;
+  const clarisIdUsernameEnvName =
+    envNames?.auth && "clarisIdUsername" in envNames.auth
+      ? getEnvName(envNames.auth.clarisIdUsername, defaultEnvNames.clarisIdUsername)
+      : defaultEnvNames.clarisIdUsername;
+  const clarisIdPasswordEnvName =
+    envNames?.auth && "clarisIdPassword" in envNames.auth
+      ? getEnvName(envNames.auth.clarisIdPassword, defaultEnvNames.clarisIdPassword)
+      : defaultEnvNames.clarisIdPassword;
   const usernameEnvName =
     envNames?.auth && "username" in envNames.auth
       ? getEnvName(envNames.auth.username, defaultEnvNames.username)
@@ -67,10 +83,11 @@ export function getEnvValues(envNames?: EnvNames): EnvValues {
       : defaultEnvNames.password;
 
   const apiKey = process.env[apiKeyEnvName];
+  const clarisIdUsername = process.env[clarisIdUsernameEnvName];
+  const clarisIdPassword = process.env[clarisIdPasswordEnvName];
   const username = process.env[usernameEnvName];
   const password = process.env[passwordEnvName];
 
-  // FM MCP env vars
   const fmMcpBaseUrlEnvName =
     envNames?.fmMcp && "baseUrl" in envNames.fmMcp
       ? getEnvName(envNames.fmMcp.baseUrl, defaultEnvNames.fmMcpBaseUrl)
@@ -87,6 +104,8 @@ export function getEnvValues(envNames?: EnvNames): EnvValues {
     server,
     db,
     apiKey,
+    clarisIdUsername,
+    clarisIdPassword,
     username,
     password,
     fmMcpBaseUrl,
@@ -97,25 +116,28 @@ export function getEnvValues(envNames?: EnvNames): EnvValues {
 /**
  * Validates environment values and returns a result with either success data or error message.
  * Follows the same validation pattern as getEnvVarsFromConfig for consistency.
- *
- * @param envValues - The environment values to validate
- * @param envNames - Optional custom environment variable names (for error messages)
- * @returns Validation result with success flag and either data or error message
  */
 export function validateEnvValues(
   envValues: EnvValues,
   envNames?: EnvNames,
-  options?: { fmMcp?: boolean; fmMcpConfig?: { baseUrl?: string; connectedFileName?: string } },
+  options?: EnvValidationOptions,
 ): EnvValidationResult {
-  const { server, db, apiKey, username, password, fmMcpBaseUrl, fmMcpConnectedFileName } = envValues;
+  const {
+    server,
+    db,
+    apiKey,
+    clarisIdUsername,
+    clarisIdPassword,
+    username,
+    password,
+    fmMcpBaseUrl,
+    fmMcpConnectedFileName,
+  } = envValues;
 
-  // FM MCP mode: resolve baseUrl and connectedFileName with fallback chain
-  // Priority: config value > env var > default/auto-discover
   if (options?.fmMcp) {
     const resolvedBaseUrl = options.fmMcpConfig?.baseUrl || fmMcpBaseUrl || defaultFmMcpBaseUrl;
     const resolvedConnectedFileName = options.fmMcpConfig?.connectedFileName || fmMcpConnectedFileName;
 
-    // connectedFileName will be auto-discovered later if still missing
     return {
       success: true,
       mode: "fmMcp",
@@ -124,33 +146,32 @@ export function validateEnvValues(
     };
   }
 
-  // Helper to get env name, treating empty strings as undefined
   const getEnvName = (customName: string | undefined, defaultName: string) =>
     customName && customName.trim() !== "" ? customName : defaultName;
 
-  // Validate required env vars (server, db, and at least one auth method)
-  if (!(server && db && (apiKey || username))) {
-    // Build missing details
+  const hasClarisIdAuth = !!(options?.allowClarisId && clarisIdUsername);
+  const hasAnyAuth = !!(apiKey || hasClarisIdAuth || username);
+
+  if (!(server && db && hasAnyAuth)) {
     const missingDetails: {
       server?: boolean;
       db?: boolean;
       auth?: boolean;
       password?: boolean;
+      clarisIdPassword?: boolean;
     } = {
       server: !server,
       db: !db,
-      auth: !(apiKey || username),
+      auth: !hasAnyAuth,
     };
 
-    // Only report password as missing if server and db are both present,
-    // and username is set but password is missing. This ensures we don't
-    // incorrectly report password as missing when the actual error is about
-    // missing server or database.
     if (server && db && username && !password) {
       missingDetails.password = true;
     }
+    if (server && db && options?.allowClarisId && clarisIdUsername && !clarisIdPassword) {
+      missingDetails.clarisIdPassword = true;
+    }
 
-    // Build error message with env var names
     const missingVars: string[] = [];
     if (!server) {
       missingVars.push(getEnvName(envNames?.server, defaultEnvNames.server));
@@ -159,11 +180,18 @@ export function validateEnvValues(
       missingVars.push(getEnvName(envNames?.db, defaultEnvNames.db));
     }
 
-    if (!(apiKey || username)) {
-      // Determine the names to display in the error message
+    if (!hasAnyAuth) {
       const apiKeyName = getEnvName(
         envNames?.auth && "apiKey" in envNames.auth ? envNames.auth.apiKey : undefined,
         defaultEnvNames.apiKey,
+      );
+      const clarisIdUsernameName = getEnvName(
+        envNames?.auth && "clarisIdUsername" in envNames.auth ? envNames.auth.clarisIdUsername : undefined,
+        defaultEnvNames.clarisIdUsername,
+      );
+      const clarisIdPasswordName = getEnvName(
+        envNames?.auth && "clarisIdPassword" in envNames.auth ? envNames.auth.clarisIdPassword : undefined,
+        defaultEnvNames.clarisIdPassword,
       );
       const usernameName = getEnvName(
         envNames?.auth && "username" in envNames.auth ? envNames.auth.username : undefined,
@@ -174,7 +202,9 @@ export function validateEnvValues(
         defaultEnvNames.password,
       );
 
-      missingVars.push(`${apiKeyName} (or ${usernameName} and ${passwordName})`);
+      missingVars.push(
+        `${apiKeyName} (or ${clarisIdUsernameName} and ${clarisIdPasswordName}, or ${usernameName} and ${passwordName})`,
+      );
     }
 
     return {
@@ -183,7 +213,18 @@ export function validateEnvValues(
     };
   }
 
-  // Validate password if username is provided
+  if (options?.allowClarisId && clarisIdUsername && !clarisIdPassword) {
+    const clarisIdPasswordName = getEnvName(
+      envNames?.auth && "clarisIdPassword" in envNames.auth ? envNames.auth.clarisIdPassword : undefined,
+      defaultEnvNames.clarisIdPassword,
+    );
+
+    return {
+      success: false,
+      errorMessage: `Password is required when using Claris ID authentication. Missing: ${clarisIdPasswordName}`,
+    };
+  }
+
   if (username && !password) {
     const passwordName = getEnvName(
       envNames?.auth && "password" in envNames.auth ? envNames.auth.password : undefined,
@@ -196,9 +237,19 @@ export function validateEnvValues(
     };
   }
 
-  const auth: { apiKey: string } | { username: string; password: string } = apiKey
-    ? { apiKey }
-    : { username: username ?? "", password: password ?? "" };
+  let auth: StandardAuth;
+  if (apiKey) {
+    auth = { apiKey };
+  } else if (hasClarisIdAuth) {
+    auth = {
+      clarisId: {
+        username: clarisIdUsername ?? "",
+        password: clarisIdPassword ?? "",
+      },
+    };
+  } else {
+    auth = { username: username ?? "", password: password ?? "" };
+  }
 
   return {
     success: true,
@@ -211,16 +262,11 @@ export function validateEnvValues(
 
 /**
  * Validates environment values and logs errors using chalk (for fmdapi compatibility).
- * Returns undefined if validation fails, otherwise returns the validated values.
- *
- * @param envValues - The environment values to validate
- * @param envNames - Optional custom environment variable names (for error messages)
- * @returns Validated values or undefined if validation failed
  */
 export function validateAndLogEnvValues(
   envValues: EnvValues,
   envNames?: EnvNames,
-  options?: { fmMcp?: boolean; fmMcpConfig?: { baseUrl?: string; connectedFileName?: string } },
+  options?: EnvValidationOptions,
 ): EnvValidationResult | undefined {
   const result = validateEnvValues(envValues, envNames, options);
 
@@ -252,7 +298,9 @@ export function validateAndLogEnvValues(
       return undefined;
     }
 
-    const { server, db, apiKey, username, password } = envValues;
+    const { server, db, apiKey, clarisIdUsername, clarisIdPassword, username, password } = envValues;
+    const hasClarisIdAuth = !!(options?.allowClarisId && clarisIdUsername);
+    const hasAnyAuth = !!(apiKey || hasClarisIdAuth || username);
 
     if (!server) {
       console.log(getEnvName(envNames?.server, defaultEnvNames.server));
@@ -261,11 +309,18 @@ export function validateAndLogEnvValues(
       console.log(getEnvName(envNames?.db, defaultEnvNames.db));
     }
 
-    if (!(apiKey || username)) {
-      // Determine the names to display in the error message
+    if (!hasAnyAuth) {
       const apiKeyNameToLog = getEnvName(
         envNames?.auth && "apiKey" in envNames.auth ? envNames.auth.apiKey : undefined,
         defaultEnvNames.apiKey,
+      );
+      const clarisIdUsernameNameToLog = getEnvName(
+        envNames?.auth && "clarisIdUsername" in envNames.auth ? envNames.auth.clarisIdUsername : undefined,
+        defaultEnvNames.clarisIdUsername,
+      );
+      const clarisIdPasswordNameToLog = getEnvName(
+        envNames?.auth && "clarisIdPassword" in envNames.auth ? envNames.auth.clarisIdPassword : undefined,
+        defaultEnvNames.clarisIdPassword,
       );
       const usernameNameToLog = getEnvName(
         envNames?.auth && "username" in envNames.auth ? envNames.auth.username : undefined,
@@ -276,7 +331,16 @@ export function validateAndLogEnvValues(
         defaultEnvNames.password,
       );
 
-      console.log(`${apiKeyNameToLog} (or ${usernameNameToLog} and ${passwordNameToLog})`);
+      console.log(
+        `${apiKeyNameToLog} (or ${clarisIdUsernameNameToLog} and ${clarisIdPasswordNameToLog}, or ${usernameNameToLog} and ${passwordNameToLog})`,
+      );
+    } else if (options?.allowClarisId && clarisIdUsername && !clarisIdPassword) {
+      console.log(
+        getEnvName(
+          envNames?.auth && "clarisIdPassword" in envNames.auth ? envNames.auth.clarisIdPassword : undefined,
+          defaultEnvNames.clarisIdPassword,
+        ),
+      );
     } else if (username && !password) {
       console.log(
         getEnvName(

--- a/packages/typegen/src/server/app.ts
+++ b/packages/typegen/src/server/app.ts
@@ -600,7 +600,7 @@ export function createApiApp(context: ApiContext) {
 
             const { db, connection, server, dbName, authType } = result;
 
-            if (authType === "username") {
+            if (authType === "username" || authType === "clarisId") {
               // Test connection by calling listDatabaseNames() and listTableNames() separately
               // First test: listDatabaseNames() - tests server connection
               try {

--- a/packages/typegen/src/server/createDataApiClient.ts
+++ b/packages/typegen/src/server/createDataApiClient.ts
@@ -43,13 +43,31 @@ type FmdapiConfig = Extract<SingleConfig, { type: "fmdapi" }>;
 
 type FmodataConfig = Extract<SingleConfig, { type: "fmodata" }>;
 
+interface ApiKeyAuth {
+  apiKey: OttoAPIKey;
+}
+
+interface UsernameAuth {
+  username: string;
+  password: string;
+}
+
+interface ClarisIdAuth {
+  clarisId: {
+    username: string;
+    password: string;
+  };
+}
+
+type SupportedAuth = ApiKeyAuth | UsernameAuth | ClarisIdAuth;
+
 type EnvVarsResult =
   | CreateClientError
   | {
       server: string;
       db: string;
-      authType: "apiKey" | "username";
-      auth: { apiKey: OttoAPIKey } | { username: string; password: string };
+      authType: "apiKey" | "username" | "clarisId";
+      auth: SupportedAuth;
     };
 
 export interface OdataClientResult {
@@ -61,7 +79,7 @@ export interface OdataClientResult {
   };
   server: string;
   dbName: string;
-  authType: "apiKey" | "username";
+  authType: "apiKey" | "username" | "clarisId";
 }
 
 export interface OdataClientError {
@@ -73,7 +91,10 @@ export interface OdataClientError {
   message?: string;
 }
 
-function getEnvVarsFromConfig(envNames: SingleConfig["envNames"]): EnvVarsResult {
+function getEnvVarsFromConfig(
+  envNames: SingleConfig["envNames"],
+  options?: { allowClarisId?: boolean },
+): EnvVarsResult {
   const getEnvName = (customName: string | undefined, defaultName: string) =>
     customName && customName.trim() !== "" ? customName : defaultName;
 
@@ -84,6 +105,14 @@ function getEnvVarsFromConfig(envNames: SingleConfig["envNames"]): EnvVarsResult
     envNames?.auth && "apiKey" in envNames.auth
       ? getEnvName(envNames.auth.apiKey, defaultEnvNames.apiKey)
       : defaultEnvNames.apiKey;
+  const clarisIdUsernameEnvName =
+    envNames?.auth && "clarisIdUsername" in envNames.auth
+      ? getEnvName(envNames.auth.clarisIdUsername, defaultEnvNames.clarisIdUsername)
+      : defaultEnvNames.clarisIdUsername;
+  const clarisIdPasswordEnvName =
+    envNames?.auth && "clarisIdPassword" in envNames.auth
+      ? getEnvName(envNames.auth.clarisIdPassword, defaultEnvNames.clarisIdPassword)
+      : defaultEnvNames.clarisIdPassword;
   const usernameEnvName =
     envNames?.auth && "username" in envNames.auth
       ? getEnvName(envNames.auth.username, defaultEnvNames.username)
@@ -94,23 +123,31 @@ function getEnvVarsFromConfig(envNames: SingleConfig["envNames"]): EnvVarsResult
       : defaultEnvNames.password;
 
   const apiKey = process.env[apiKeyEnvName];
+  const clarisIdUsername = process.env[clarisIdUsernameEnvName];
+  const clarisIdPassword = process.env[clarisIdPasswordEnvName];
   const username = process.env[usernameEnvName];
   const password = process.env[passwordEnvName];
+  const hasClarisIdAuth = !!(options?.allowClarisId && clarisIdUsername);
+  const hasAnyAuth = !!(apiKey || hasClarisIdAuth || username);
 
-  if (!(server && db && (apiKey || username))) {
+  if (!(server && db && hasAnyAuth)) {
     const missingDetails: {
       server?: boolean;
       db?: boolean;
       auth?: boolean;
       password?: boolean;
+      clarisIdPassword?: boolean;
     } = {
       server: !server,
       db: !db,
-      auth: !(apiKey || username),
+      auth: !hasAnyAuth,
     };
 
     if (server && db && username && !password) {
       missingDetails.password = true;
+    }
+    if (server && db && options?.allowClarisId && clarisIdUsername && !clarisIdPassword) {
+      missingDetails.clarisIdPassword = true;
     }
 
     return {
@@ -127,7 +164,7 @@ function getEnvVarsFromConfig(envNames: SingleConfig["envNames"]): EnvVarsResult
         if (!db) {
           return "db";
         }
-        if (!(apiKey || username)) {
+        if (!hasAnyAuth) {
           return "auth";
         }
         return undefined;
@@ -141,6 +178,21 @@ function getEnvVarsFromConfig(envNames: SingleConfig["envNames"]): EnvVarsResult
         }
         return "Authentication credentials environment variable is missing";
       })(),
+    };
+  }
+
+  if (options?.allowClarisId && clarisIdUsername && !clarisIdPassword) {
+    return {
+      error: "Password is required when using Claris ID authentication",
+      statusCode: 400,
+      kind: "missing_env",
+      details: {
+        missing: {
+          clarisIdPassword: true,
+        },
+      },
+      suspectedField: "auth",
+      message: "Claris ID password environment variable is missing",
     };
   }
 
@@ -159,11 +211,29 @@ function getEnvVarsFromConfig(envNames: SingleConfig["envNames"]): EnvVarsResult
     };
   }
 
+  let authType: "apiKey" | "username" | "clarisId";
+  let auth: SupportedAuth;
+  if (apiKey) {
+    authType = "apiKey";
+    auth = { apiKey: apiKey as OttoAPIKey };
+  } else if (hasClarisIdAuth) {
+    authType = "clarisId";
+    auth = {
+      clarisId: {
+        username: clarisIdUsername ?? "",
+        password: clarisIdPassword ?? "",
+      },
+    };
+  } else {
+    authType = "username";
+    auth = { username: username ?? "", password: password ?? "" };
+  }
+
   return {
     server,
     db,
-    authType: apiKey ? "apiKey" : "username",
-    auth: apiKey ? { apiKey: apiKey as OttoAPIKey } : { username: username ?? "", password: password ?? "" },
+    authType,
+    auth,
   };
 }
 
@@ -201,7 +271,7 @@ async function loadFmodataDeps() {
 export async function createOdataClientFromConfig(
   config: FmodataConfig,
 ): Promise<OdataClientResult | OdataClientError> {
-  const result = getEnvVarsFromConfig(config.envNames);
+  const result = getEnvVarsFromConfig(config.envNames, { allowClarisId: true });
   if ("error" in result) {
     return result;
   }
@@ -312,9 +382,21 @@ export async function createClientFromConfig(
     return result;
   }
 
-  const { server, db, authType, auth } = result;
+  const { server, db, auth } = result;
 
   try {
+    if ("clarisId" in auth) {
+      return {
+        error: "Claris ID auth is not supported for fmdapi adapters",
+        statusCode: 400,
+        kind: "adapter_error",
+        suspectedField: "auth",
+        message: "Claris ID auth is not supported for fmdapi adapters",
+      };
+    }
+
+    const resolvedAuthType: "apiKey" | "username" = "apiKey" in auth ? "apiKey" : "username";
+
     const client =
       "apiKey" in auth
         ? DataApi({
@@ -335,7 +417,7 @@ export async function createClientFromConfig(
       client: client as CreateClientResult["client"],
       server,
       db,
-      authType,
+      authType: resolvedAuthType,
     };
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : "Failed to create adapter";

--- a/packages/typegen/src/typegen.ts
+++ b/packages/typegen/src/typegen.ts
@@ -262,6 +262,10 @@ const generateTypedClientsSingle = async (
     server = validationResult.server;
     db = validationResult.db;
     const validatedAuth = validationResult.auth;
+    if ("clarisId" in validatedAuth) {
+      console.log(chalk.red("ERROR: Claris ID auth is not supported for fmdapi type generation."));
+      return;
+    }
     auth = "apiKey" in validatedAuth ? { apiKey: validatedAuth.apiKey as OttoAPIKey } : validatedAuth;
   }
 

--- a/packages/typegen/src/types.ts
+++ b/packages/typegen/src/types.ts
@@ -33,6 +33,8 @@ export const envNamesBase = z
         apiKey: z.string().optional(),
         username: z.string().optional(),
         password: z.string().optional(),
+        clarisIdUsername: z.string().optional(),
+        clarisIdPassword: z.string().optional(),
       })
       .optional(),
     fmMcp: z
@@ -64,6 +66,8 @@ const envNames = envNamesBase
             apiKey: val.auth.apiKey === "" ? undefined : val.auth.apiKey,
             username: val.auth.username === "" ? undefined : val.auth.username,
             password: val.auth.password === "" ? undefined : val.auth.password,
+            clarisIdUsername: val.auth.clarisIdUsername === "" ? undefined : val.auth.clarisIdUsername,
+            clarisIdPassword: val.auth.clarisIdPassword === "" ? undefined : val.auth.clarisIdPassword,
           }
         : undefined,
       fmMcp: val.fmMcp

--- a/packages/typegen/tests/getEnvValues.test.ts
+++ b/packages/typegen/tests/getEnvValues.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getEnvValues, validateEnvValues } from "../src/getEnvValues";
 
+const CLARIS_AUTH_RE = /Claris ID authentication/i;
+
 describe("getEnvValues + validateEnvValues", () => {
   const originalEnv: Record<string, string | undefined> = {};
 
@@ -9,6 +11,8 @@ describe("getEnvValues + validateEnvValues", () => {
       "FM_SERVER",
       "FM_DATABASE",
       "OTTO_API_KEY",
+      "CLARIS_ID_USERNAME",
+      "CLARIS_ID_PASSWORD",
       "FM_USERNAME",
       "FM_PASSWORD",
       "FM_MCP_BASE_URL",
@@ -16,6 +20,8 @@ describe("getEnvValues + validateEnvValues", () => {
       "CUSTOM_SERVER",
       "CUSTOM_DB",
       "CUSTOM_KEY",
+      "CUSTOM_CLARIS_USER",
+      "CUSTOM_CLARIS_PASS",
       "CUSTOM_HTTP_URL",
       "CUSTOM_HTTP_FILE",
     ]) {
@@ -66,6 +72,40 @@ describe("getEnvValues + validateEnvValues", () => {
     }
   });
 
+  it("validates standard mode with Claris ID auth when enabled", () => {
+    process.env.FM_SERVER = "https://example.com";
+    process.env.FM_DATABASE = "MyDB";
+    process.env.CLARIS_ID_USERNAME = "claris-user";
+    process.env.CLARIS_ID_PASSWORD = "claris-pass";
+
+    const envValues = getEnvValues();
+    const result = validateEnvValues(envValues, undefined, { allowClarisId: true });
+
+    expect(result.success).toBe(true);
+    if (result.success && result.mode === "standard") {
+      expect(result.auth).toEqual({
+        clarisId: {
+          username: "claris-user",
+          password: "claris-pass",
+        },
+      });
+    }
+  });
+
+  it("requires Claris ID password when using Claris ID auth", () => {
+    process.env.FM_SERVER = "https://example.com";
+    process.env.FM_DATABASE = "MyDB";
+    process.env.CLARIS_ID_USERNAME = "claris-user";
+
+    const envValues = getEnvValues();
+    const result = validateEnvValues(envValues, undefined, { allowClarisId: true });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errorMessage).toMatch(CLARIS_AUTH_RE);
+    }
+  });
+
   it("defaults baseUrl and allows empty connectedFileName for auto-discovery when fmMcp env vars are missing", () => {
     const envValues = getEnvValues();
     const result = validateEnvValues(envValues, undefined, { fmMcp: true });
@@ -98,19 +138,27 @@ describe("getEnvValues + validateEnvValues", () => {
     process.env.CUSTOM_SERVER = "https://custom.example.com";
     process.env.CUSTOM_DB = "CustomDB";
     process.env.CUSTOM_KEY = "KEY_custom_123";
+    process.env.CUSTOM_CLARIS_USER = "claris-user";
+    process.env.CUSTOM_CLARIS_PASS = "claris-pass";
     process.env.CUSTOM_HTTP_URL = "http://127.0.0.1:1365";
     process.env.CUSTOM_HTTP_FILE = "CustomFile";
 
     const envValues = getEnvValues({
       server: "CUSTOM_SERVER",
       db: "CUSTOM_DB",
-      auth: { apiKey: "CUSTOM_KEY" },
+      auth: {
+        apiKey: "CUSTOM_KEY",
+        clarisIdUsername: "CUSTOM_CLARIS_USER",
+        clarisIdPassword: "CUSTOM_CLARIS_PASS",
+      },
       fmMcp: { baseUrl: "CUSTOM_HTTP_URL", connectedFileName: "CUSTOM_HTTP_FILE" },
     });
 
     expect(envValues.server).toBe("https://custom.example.com");
     expect(envValues.db).toBe("CustomDB");
     expect(envValues.apiKey).toBe("KEY_custom_123");
+    expect(envValues.clarisIdUsername).toBe("claris-user");
+    expect(envValues.clarisIdPassword).toBe("claris-pass");
     expect(envValues.fmMcpBaseUrl).toBe("http://127.0.0.1:1365");
     expect(envValues.fmMcpConnectedFileName).toBe("CustomFile");
   });

--- a/packages/typegen/tests/odata-client-config.test.ts
+++ b/packages/typegen/tests/odata-client-config.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createOdataClientFromConfig } from "../src/server/createDataApiClient";
+
+const CLARIS_PASSWORD_RE = /Claris ID password/i;
+
+describe("createOdataClientFromConfig", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns clarisId authType for fmodata config", async () => {
+    process.env.FM_SERVER = "https://example.com";
+    process.env.FM_DATABASE = "MyDB.fmp12";
+    process.env.CLARIS_ID_USERNAME = "claris-user";
+    process.env.CLARIS_ID_PASSWORD = "claris-pass";
+
+    const result = await createOdataClientFromConfig({
+      type: "fmodata",
+      path: "schema",
+      validator: "zod/v4",
+      tables: [],
+    });
+
+    expect("error" in result).toBe(false);
+    if (!("error" in result)) {
+      expect(result.authType).toBe("clarisId");
+    }
+  });
+
+  it("returns missing env error when claris password is absent", async () => {
+    process.env.FM_SERVER = "https://example.com";
+    process.env.FM_DATABASE = "MyDB.fmp12";
+    process.env.CLARIS_ID_USERNAME = "claris-user";
+    process.env.CLARIS_ID_PASSWORD = undefined;
+
+    const result = await createOdataClientFromConfig({
+      type: "fmodata",
+      path: "schema",
+      validator: "zod/v4",
+      tables: [],
+    });
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.message).toMatch(CLARIS_PASSWORD_RE);
+    }
+  });
+});

--- a/packages/typegen/vitest.config.ts
+++ b/packages/typegen/vitest.config.ts
@@ -1,6 +1,35 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@proofkit\/fmdapi$/,
+        replacement: path.resolve(__dirname, "../fmdapi/src/index.ts"),
+      },
+      {
+        find: /^@proofkit\/fmdapi\/adapters\/fetch$/,
+        replacement: path.resolve(__dirname, "../fmdapi/src/adapters/fetch.ts"),
+      },
+      {
+        find: /^@proofkit\/fmdapi\/adapters\/fm-mcp$/,
+        replacement: path.resolve(__dirname, "../fmdapi/src/adapters/fm-mcp.ts"),
+      },
+      {
+        find: /^@proofkit\/fmdapi\/adapters\/otto$/,
+        replacement: path.resolve(__dirname, "../fmdapi/src/adapters/otto.ts"),
+      },
+      {
+        find: /^@proofkit\/fmdapi\/tokenStore\/memory$/,
+        replacement: path.resolve(__dirname, "../fmdapi/src/tokenStore/memory.ts"),
+      },
+      {
+        find: /^@proofkit\/fmodata$/,
+        replacement: path.resolve(__dirname, "../fmodata/src/index.ts"),
+      },
+    ],
+  },
   test: {
     testTimeout: 15_000,
     setupFiles: ["./tests/setupEnv.ts"],

--- a/packages/typegen/web/src/components/EnvVarDialog.tsx
+++ b/packages/typegen/web/src/components/EnvVarDialog.tsx
@@ -63,6 +63,22 @@ export function EnvVarDialog({ index }: EnvVarDialogProps) {
     envNamesAuth.apiKey.trim() !== ""
       ? envNamesAuth.apiKey
       : defaultEnvNames.apiKey;
+  const clarisIdUsernameEnvName =
+    envNamesAuth &&
+    typeof envNamesAuth === "object" &&
+    "clarisIdUsername" in envNamesAuth &&
+    envNamesAuth.clarisIdUsername &&
+    envNamesAuth.clarisIdUsername.trim() !== ""
+      ? envNamesAuth.clarisIdUsername
+      : defaultEnvNames.clarisIdUsername;
+  const clarisIdPasswordEnvName =
+    envNamesAuth &&
+    typeof envNamesAuth === "object" &&
+    "clarisIdPassword" in envNamesAuth &&
+    envNamesAuth.clarisIdPassword &&
+    envNamesAuth.clarisIdPassword.trim() !== ""
+      ? envNamesAuth.clarisIdPassword
+      : defaultEnvNames.clarisIdPassword;
   const usernameEnvName =
     envNamesAuth &&
     typeof envNamesAuth === "object" &&
@@ -80,16 +96,28 @@ export function EnvVarDialog({ index }: EnvVarDialogProps) {
       ? envNamesAuth.password
       : defaultEnvNames.password;
 
-  // Resolve all three auth env values
+  // Resolve all auth env values
   const { data: apiKeyValue, isLoading: apiKeyLoading } = useEnvValue(apiKeyEnvName);
+  const { data: clarisIdUsernameValue, isLoading: clarisIdUsernameLoading } = useEnvValue(clarisIdUsernameEnvName);
+  const { data: clarisIdPasswordValue, isLoading: clarisIdPasswordLoading } = useEnvValue(clarisIdPasswordEnvName);
   const { data: usernameValue, isLoading: usernameLoading } = useEnvValue(usernameEnvName);
   const { data: passwordValue, isLoading: passwordLoading } = useEnvValue(passwordEnvName);
 
   // Determine which authentication method will be used
-  // Default to API key if it resolves to a value, otherwise use username/password if both resolve
-  let activeAuthMethod: "apiKey" | "username" | null = null;
+  // Precedence matches server-side auth resolution
+  let activeAuthMethod: "apiKey" | "clarisId" | "username" | null = null;
   if (!apiKeyLoading && apiKeyValue !== undefined && apiKeyValue !== null && apiKeyValue !== "") {
     activeAuthMethod = "apiKey";
+  } else if (
+    !(clarisIdUsernameLoading || clarisIdPasswordLoading) &&
+    clarisIdUsernameValue !== undefined &&
+    clarisIdUsernameValue !== null &&
+    clarisIdUsernameValue !== "" &&
+    clarisIdPasswordValue !== undefined &&
+    clarisIdPasswordValue !== null &&
+    clarisIdPasswordValue !== ""
+  ) {
+    activeAuthMethod = "clarisId";
   } else if (
     !(usernameLoading || passwordLoading) &&
     usernameValue !== undefined &&
@@ -115,6 +143,14 @@ export function EnvVarDialog({ index }: EnvVarDialogProps) {
   // Check if any values resolve to undefined/null/empty (only check after loading completes)
   // For auth, check that at least one complete auth method is configured (either API key OR username+password)
   const hasApiKeyAuth = !apiKeyLoading && apiKeyValue !== undefined && apiKeyValue !== null && apiKeyValue !== "";
+  const hasClarisIdAuth =
+    !(clarisIdUsernameLoading || clarisIdPasswordLoading) &&
+    clarisIdUsernameValue !== undefined &&
+    clarisIdUsernameValue !== null &&
+    clarisIdUsernameValue !== "" &&
+    clarisIdPasswordValue !== undefined &&
+    clarisIdPasswordValue !== null &&
+    clarisIdPasswordValue !== "";
   const hasUsernamePasswordAuth =
     !(usernameLoading || passwordLoading) &&
     usernameValue !== undefined &&
@@ -123,12 +159,19 @@ export function EnvVarDialog({ index }: EnvVarDialogProps) {
     passwordValue !== undefined &&
     passwordValue !== null &&
     passwordValue !== "";
-  const hasAuth = hasApiKeyAuth || hasUsernamePasswordAuth;
+  const hasAuth = hasApiKeyAuth || hasClarisIdAuth || hasUsernamePasswordAuth;
 
   const hasUndefinedValues =
     (!serverLoading && (serverValue === undefined || serverValue === null || serverValue === "")) ||
     (!dbLoading && (dbValue === undefined || dbValue === null || dbValue === "")) ||
-    !(apiKeyLoading || usernameLoading || passwordLoading || hasAuth);
+    !(
+      apiKeyLoading ||
+      clarisIdUsernameLoading ||
+      clarisIdPasswordLoading ||
+      usernameLoading ||
+      passwordLoading ||
+      hasAuth
+    );
 
   // Initialize auth fields if not already set
   useEffect(() => {
@@ -136,6 +179,8 @@ export function EnvVarDialog({ index }: EnvVarDialogProps) {
     if (!currentAuth) {
       setValue(`config.${index}.envNames.auth` as const, {
         apiKey: "",
+        clarisIdUsername: "",
+        clarisIdPassword: "",
         username: "",
         password: "",
       });
@@ -143,11 +188,20 @@ export function EnvVarDialog({ index }: EnvVarDialogProps) {
       // Ensure all fields exist
       setValue(`config.${index}.envNames.auth` as const, {
         apiKey: currentAuth.apiKey || "",
+        clarisIdUsername: currentAuth.clarisIdUsername || "",
+        clarisIdPassword: currentAuth.clarisIdPassword || "",
         username: currentAuth.username || "",
         password: currentAuth.password || "",
       });
     }
   }, [setValue, getValues, index]);
+
+  let authTypeLabel = "Username/Password";
+  if (testData?.authType === "apiKey") {
+    authTypeLabel = "API Key";
+  } else if (testData?.authType === "clarisId") {
+    authTypeLabel = "Claris ID";
+  }
 
   return (
     <Dialog onOpenChange={setDialogOpenState} open={dialogOpen}>
@@ -208,6 +262,30 @@ export function EnvVarDialog({ index }: EnvVarDialogProps) {
                   />
 
                   {/* OR Divider */}
+                  <div className="flex items-center gap-3">
+                    <Separator className="flex-1" />
+                    <span className="font-medium text-muted-foreground text-sm">OR</span>
+                    <Separator className="flex-1" />
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    <EnvVarField
+                      defaultValue={defaultEnvNames.clarisIdUsername}
+                      dimField={activeAuthMethod !== "clarisId"}
+                      fieldName={`config.${index}.envNames.auth.clarisIdUsername` as const}
+                      label="Claris ID Username"
+                      placeholder={defaultEnvNames.clarisIdUsername}
+                    />
+
+                    <EnvVarField
+                      defaultValue={defaultEnvNames.clarisIdPassword}
+                      dimField={activeAuthMethod !== "clarisId"}
+                      fieldName={`config.${index}.envNames.auth.clarisIdPassword` as const}
+                      label="Claris ID Password"
+                      placeholder={defaultEnvNames.clarisIdPassword}
+                    />
+                  </div>
+
                   <div className="flex items-center gap-3">
                     <Separator className="flex-1" />
                     <span className="font-medium text-muted-foreground text-sm">OR</span>
@@ -306,8 +384,7 @@ export function EnvVarDialog({ index }: EnvVarDialogProps) {
                         <span className="font-medium">Database:</span> {testData.db}
                       </div>
                       <div>
-                        <span className="font-medium">Auth Type:</span>{" "}
-                        {testData.authType === "apiKey" ? "API Key" : "Username/Password"}
+                        <span className="font-medium">Auth Type:</span> {authTypeLabel}
                       </div>
                     </div>
                   </div>
@@ -339,6 +416,9 @@ export function EnvVarDialog({ index }: EnvVarDialogProps) {
                               )}
                               {errorDetails.details.missing.password && (
                                 <li>Password ({errorDetails.suspectedField === "auth" && "⚠️"})</li>
+                              )}
+                              {errorDetails.details.missing.clarisIdPassword && (
+                                <li>Claris ID Password ({errorDetails.suspectedField === "auth" && "⚠️"})</li>
                               )}
                             </ul>
                           </div>

--- a/packages/typegen/web/src/components/LayoutSelector.tsx
+++ b/packages/typegen/web/src/components/LayoutSelector.tsx
@@ -171,6 +171,12 @@ export function LayoutSelector({ configIndex, path }: { configIndex: number; pat
                                           {errorDetails.suspectedField === "auth" && " ⚠️"}
                                         </li>
                                       )}
+                                      {errorDetails.missing.clarisIdPassword && (
+                                        <li>
+                                          Claris ID Password
+                                          {errorDetails.suspectedField === "auth" && " ⚠️"}
+                                        </li>
+                                      )}
                                     </ul>
                                   </div>
                                 )}

--- a/packages/typegen/web/src/components/useEnvVarIndicator.ts
+++ b/packages/typegen/web/src/components/useEnvVarIndicator.ts
@@ -29,6 +29,12 @@ export function useEnvVarIndicator(index: number) {
   if (envNamesAuth && typeof envNamesAuth === "object") {
     if ("apiKey" in envNamesAuth && envNamesAuth.apiKey && envNamesAuth.apiKey.trim() !== "") {
       authEnvName = envNamesAuth.apiKey;
+    } else if (
+      "clarisIdUsername" in envNamesAuth &&
+      envNamesAuth.clarisIdUsername &&
+      envNamesAuth.clarisIdUsername.trim() !== ""
+    ) {
+      authEnvName = envNamesAuth.clarisIdUsername;
     } else if ("username" in envNamesAuth && envNamesAuth.username && envNamesAuth.username.trim() !== "") {
       authEnvName = envNamesAuth.username;
     }
@@ -47,6 +53,12 @@ export function useEnvVarIndicator(index: number) {
     (envNamesAuth &&
       typeof envNamesAuth === "object" &&
       (("apiKey" in envNamesAuth && envNamesAuth.apiKey && envNamesAuth.apiKey.trim() !== "") ||
+        ("clarisIdUsername" in envNamesAuth &&
+          envNamesAuth.clarisIdUsername &&
+          envNamesAuth.clarisIdUsername.trim() !== "") ||
+        ("clarisIdPassword" in envNamesAuth &&
+          envNamesAuth.clarisIdPassword &&
+          envNamesAuth.clarisIdPassword.trim() !== "") ||
         ("username" in envNamesAuth && envNamesAuth.username && envNamesAuth.username.trim() !== "") ||
         ("password" in envNamesAuth && envNamesAuth.password && envNamesAuth.password.trim() !== "")));
 

--- a/packages/typegen/web/src/hooks/useTestConnection.ts
+++ b/packages/typegen/web/src/hooks/useTestConnection.ts
@@ -24,7 +24,7 @@ export interface TestConnectionResult {
   ok: boolean;
   server?: string;
   db?: string;
-  authType?: "apiKey" | "username";
+  authType?: "apiKey" | "username" | "clarisId";
   error?: string;
   statusCode?: number;
   details?: {
@@ -33,6 +33,7 @@ export interface TestConnectionResult {
       db?: boolean;
       auth?: boolean;
       password?: boolean;
+      clarisIdPassword?: boolean;
     };
   };
   kind?: "missing_env" | "adapter_error" | "connection_error" | "unknown";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,7 +401,7 @@ importers:
         version: 11.0.0-rc.441(@trpc/server@11.0.0-rc.441)
       '@trpc/next':
         specifier: 11.0.0-rc.441
-        version: 11.0.0-rc.441(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.0.0-rc.441(@trpc/server@11.0.0-rc.441))(@trpc/react-query@11.0.0-rc.441(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.0.0-rc.441(@trpc/server@11.0.0-rc.441))(@trpc/server@11.0.0-rc.441)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@trpc/server@11.0.0-rc.441)(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 11.0.0-rc.441(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.0.0-rc.441(@trpc/server@11.0.0-rc.441))(@trpc/react-query@11.0.0-rc.441(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.0.0-rc.441(@trpc/server@11.0.0-rc.441))(@trpc/server@11.0.0-rc.441)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@trpc/server@11.0.0-rc.441)(next@16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@trpc/react-query':
         specifier: 11.0.0-rc.441
         version: 11.0.0-rc.441(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.0.0-rc.441(@trpc/server@11.0.0-rc.441))(@trpc/server@11.0.0-rc.441)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -446,7 +446,7 @@ importers:
         version: 16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 4.24.13(next@16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       postgres:
         specifier: ^3.4.8
         version: 3.4.8
@@ -492,7 +492,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@types/node@25.0.6)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.17(@types/node@25.0.6)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
   packages/fmdapi:
     dependencies:
@@ -557,6 +557,9 @@ importers:
       '@fetchkit/ffetch':
         specifier: ^4.2.0
         version: 4.2.0
+      amazon-cognito-identity-js:
+        specifier: ^6.3.16
+        version: 6.3.16
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
@@ -745,7 +748,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@types/node@25.0.6)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.17(@types/node@25.0.6)(@vitest/ui@3.2.4)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
   packages/typegen/web:
     dependencies:
@@ -975,6 +978,19 @@ packages:
     resolution: {integrity: sha512-PQU8/Oi5gfjzb0MkhMGVX0Dg877phPzsQdK54+C7ubukCeZPjyvuSAx1vVtWEYVWp2oQvjgG/C6QiDoeC7S10A==}
     peerDependencies:
       '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5'
+
+  '@aws-crypto/sha256-js@1.2.2':
+    resolution: {integrity: sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==}
+
+  '@aws-crypto/util@1.2.2':
+    resolution: {integrity: sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==}
+
+  '@aws-sdk/types@3.973.6':
+    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
 
   '@azu/format-text@1.0.2':
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
@@ -1511,11 +1527,20 @@ packages:
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
 
+  '@emnapi/core@1.9.1':
+    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -2681,6 +2706,12 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
+  '@napi-rs/wasm-runtime@1.1.2':
+    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
@@ -2768,8 +2799,8 @@ packages:
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
 
-  '@oxc-project/types@0.122.0':
-    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+  '@oxc-project/types@0.123.0':
+    resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.16.2':
     resolution: {integrity: sha512-lVJbvydLQIDZHKUb6Zs9Rq80QVTQ9xdCQE30eC9/cjg4wsMoEOg65QZPymUAIVJotpUAWJD0XYcwE7ugfxx5kQ==}
@@ -3772,91 +3803,91 @@ packages:
     peerDependencies:
       react: '>=18.2.0'
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+    resolution: {integrity: sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+    resolution: {integrity: sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+    resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+    resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+    resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
-    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+    resolution: {integrity: sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
+    resolution: {integrity: sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3864,8 +3895,8 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
-  '@rolldown/pluginutils@1.0.0-rc.12':
-    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+  '@rolldown/pluginutils@1.0.0-rc.13':
+    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
 
   '@rollup/plugin-replace@6.0.3':
     resolution: {integrity: sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==}
@@ -4110,6 +4141,10 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@smithy/types@4.14.0':
+    resolution: {integrity: sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==}
+    engines: {node: '>=18.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -4730,6 +4765,9 @@ packages:
   alien-signals@0.4.14:
     resolution: {integrity: sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==}
 
+  amazon-cognito-identity-js@6.3.16:
+    resolution: {integrity: sha512-HPGSBGD6Q36t99puWh0LnptxO/4icnk2kqIQ9cTJ2tFQo5NMUnWQIgtrTAk8nm+caqUbjDzXzG56GBjI2tS6jQ==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -4958,6 +4996,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -5763,6 +5804,9 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  fast-base64-decode@1.0.0:
+    resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
+
   fast-check@3.23.2:
     resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
     engines: {node: '>=8.0.0'}
@@ -6418,8 +6462,14 @@ packages:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-unfetch@3.1.0:
+    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -6483,6 +6533,9 @@ packages:
 
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
+  js-cookie@2.2.1:
+    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7260,6 +7313,15 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -7911,8 +7973,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-rc.12:
-    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+  rolldown@1.0.0-rc.13:
+    resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -8395,6 +8457,9 @@ packages:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
@@ -8484,6 +8549,9 @@ packages:
         optional: true
       unplugin-unused:
         optional: true
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -8587,6 +8655,9 @@ packages:
   undici@7.24.4:
     resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
     engines: {node: '>=20.18.1'}
+
+  unfetch@4.2.0:
+    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
 
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
@@ -8844,6 +8915,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -8855,6 +8929,9 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -9051,6 +9128,27 @@ snapshots:
       - '@simplewebauthn/browser'
       - '@simplewebauthn/server'
       - nodemailer
+
+  '@aws-crypto/sha256-js@1.2.2':
+    dependencies:
+      '@aws-crypto/util': 1.2.2
+      '@aws-sdk/types': 3.973.6
+      tslib: 1.14.1
+
+  '@aws-crypto/util@1.2.2':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-utf8-browser': 3.259.0
+      tslib: 1.14.1
+
+  '@aws-sdk/types@3.973.6':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    dependencies:
+      tslib: 2.8.1
 
   '@azu/format-text@1.0.2': {}
 
@@ -9727,12 +9825,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.9.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -10713,6 +10827,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+    dependencies:
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@neon-rs/load@0.0.4': {}
 
   '@next/env@16.1.1': {}
@@ -10768,7 +10889,7 @@ snapshots:
 
   '@orama/orama@3.1.18': {}
 
-  '@oxc-project/types@0.122.0': {}
+  '@oxc-project/types@0.123.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.16.2':
     optional: true
@@ -11738,56 +11859,58 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+  '@rolldown/binding-android-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@emnapi/core': 1.9.1
+      '@emnapi/runtime': 1.9.1
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.12': {}
+  '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@rollup/plugin-replace@6.0.3(rollup@4.55.1)':
     dependencies:
@@ -12051,6 +12174,10 @@ snapshots:
   '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@smithy/types@4.14.0':
+    dependencies:
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -12344,7 +12471,7 @@ snapshots:
     dependencies:
       '@trpc/server': 11.0.0-rc.441
 
-  '@trpc/next@11.0.0-rc.441(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.0.0-rc.441(@trpc/server@11.0.0-rc.441))(@trpc/react-query@11.0.0-rc.441(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.0.0-rc.441(@trpc/server@11.0.0-rc.441))(@trpc/server@11.0.0-rc.441)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@trpc/server@11.0.0-rc.441)(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@trpc/next@11.0.0-rc.441(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.0.0-rc.441(@trpc/server@11.0.0-rc.441))(@trpc/react-query@11.0.0-rc.441(@tanstack/react-query@5.90.16(react@19.2.3))(@trpc/client@11.0.0-rc.441(@trpc/server@11.0.0-rc.441))(@trpc/server@11.0.0-rc.441)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@trpc/server@11.0.0-rc.441)(next@16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@trpc/client': 11.0.0-rc.441(@trpc/server@11.0.0-rc.441)
       '@trpc/server': 11.0.0-rc.441
@@ -12677,14 +12804,14 @@ snapshots:
       msw: 2.12.7(@types/node@22.19.5)(typescript@5.9.3)
       vite: 6.4.1(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.0.17(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(vite@6.4.1(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.17(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(vite@6.4.1(@types/node@25.0.6)(jiti@1.21.7)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@25.0.6)(typescript@5.9.3)
-      vite: 6.4.1(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.6)(jiti@1.21.7)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.17(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(vite@6.4.1(@types/node@25.0.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -12843,6 +12970,16 @@ snapshots:
       require-from-string: 2.0.2
 
   alien-signals@0.4.14: {}
+
+  amazon-cognito-identity-js@6.3.16:
+    dependencies:
+      '@aws-crypto/sha256-js': 1.2.2
+      buffer: 4.9.2
+      fast-base64-decode: 1.0.0
+      isomorphic-unfetch: 3.1.0
+      js-cookie: 2.2.1
+    transitivePeerDependencies:
+      - encoding
 
   ansi-colors@4.1.3: {}
 
@@ -13038,6 +13175,12 @@ snapshots:
   bson@7.2.0: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@4.9.2:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
 
   buffer@5.7.1:
     dependencies:
@@ -13874,6 +14017,8 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
+  fast-base64-decode@1.0.0: {}
+
   fast-check@3.23.2:
     dependencies:
       pure-rand: 6.1.0
@@ -14578,7 +14723,16 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
+
+  isomorphic-unfetch@3.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -14655,6 +14809,8 @@ snapshots:
   jose@6.1.3: {}
 
   js-base64@3.7.8: {}
+
+  js-cookie@2.2.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -15704,7 +15860,7 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
-  next-auth@4.24.13(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next-auth@4.24.13(next@16.1.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.4
       '@panva/hkdf': 1.2.1
@@ -15767,6 +15923,10 @@ snapshots:
       skin-tone: 2.0.0
 
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -16549,7 +16709,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.15.10(oxc-resolver@11.16.2)(rolldown@1.0.0-rc.12)(typescript@5.9.3):
+  rolldown-plugin-dts@0.15.10(oxc-resolver@11.16.2)(rolldown@1.0.0-rc.13)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -16559,33 +16719,33 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       dts-resolver: 2.1.3(oxc-resolver@11.16.2)
       get-tsconfig: 4.13.0
-      rolldown: 1.0.0-rc.12
+      rolldown: 1.0.0-rc.13
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.0.0-rc.12:
+  rolldown@1.0.0-rc.13:
     dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
+      '@oxc-project/types': 0.123.0
+      '@rolldown/pluginutils': 1.0.0-rc.13
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-android-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.13
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.13
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.13
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.13
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.13
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.13
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.13
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
 
   rollup-plugin-preserve-directives@0.4.0(rollup@4.55.1):
     dependencies:
@@ -17187,6 +17347,8 @@ snapshots:
     dependencies:
       tldts: 7.0.19
 
+  tr46@0.0.3: {}
+
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -17243,8 +17405,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.0-rc.12
-      rolldown-plugin-dts: 0.15.10(oxc-resolver@11.16.2)(rolldown@1.0.0-rc.12)(typescript@5.9.3)
+      rolldown: 1.0.0-rc.13
+      rolldown-plugin-dts: 0.15.10(oxc-resolver@11.16.2)(rolldown@1.0.0-rc.13)(typescript@5.9.3)
       semver: 7.7.3
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
@@ -17258,6 +17420,8 @@ snapshots:
       - oxc-resolver
       - supports-color
       - vue-tsc
+
+  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
@@ -17368,6 +17532,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici@7.24.4: {}
+
+  unfetch@4.2.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -17783,7 +17949,7 @@ snapshots:
   vitest@4.0.17(@types/node@25.0.6)(happy-dom@20.1.0)(jiti@1.21.7)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(vite@6.4.1(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.17(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(vite@6.4.1(@types/node@25.0.6)(jiti@1.21.7)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17
@@ -17818,44 +17984,6 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.17(@types/node@25.0.6)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(msw@2.12.7(@types/node@25.0.6)(typescript@5.9.3))(vite@6.4.1(@types/node@22.19.5)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.0.17
-      '@vitest/runner': 4.0.17
-      '@vitest/snapshot': 4.0.17
-      '@vitest/spy': 4.0.17
-      '@vitest/utils': 4.0.17
-      es-module-lexer: 1.7.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@25.0.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.0.6
-      happy-dom: 20.1.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
-
   vscode-uri@3.1.0: {}
 
   walk-up-path@4.0.0: {}
@@ -17866,6 +17994,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@7.0.0: {}
 
   whatwg-mimetype@3.0.0: {}
@@ -17874,6 +18004,11 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-module@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- Add Claris ID auth flow to `@proofkit/fmodata` for FileMaker Cloud.
- Extend CLI, env handling, and connection setup to accept Claris ID credentials.
- Update typegen to detect and configure Claris ID env vars and connection metadata.
- Add tests for token handling, MFA rejection, CLI/env wiring, and request auth headers.
- Update docs and agent skills with Claris ID usage notes.

## Testing
- `pnpm run ci` not run.
- Added/updated unit tests for Claris ID auth manager and CLI connection parsing.
- Added typegen env/config tests for Claris ID paths.
- Added request-level test for `FMID` auth header propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claris ID authentication added for FileMaker Cloud across CLI, SDK, and web tooling; new CLI options and matching env vars for username/password.
  * Typegen/tooling recognizes Claris ID for connection testing; generator will skip producing adapters when Claris ID auth is used.

* **Documentation**
  * Docs and READMEs updated with Claris ID setup notes and that MFA-backed Claris ID accounts are not supported; tokens are managed and auto-refreshed.

* **Tests**
  * New tests cover Claris ID authentication, token refresh, and CLI/env validation.

* **Style**
  * Minor formatting adjustments to docs/layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->