### PR TITLE
chore: add onlyBuiltDependencies after installing amazon-cognito-identity-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,18 @@
       "qs": "^6.14.1",
       "vite": "^6.4.1",
       "body-parser": "^2.2.1"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "@prisma/client",
+      "@prisma/engines",
+      "better-sqlite3",
+      "es5-ext",
+      "esbuild",
+      "msgpackr-extract",
+      "msw",
+      "prisma",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- `pnpm install` auto-generated an `onlyBuiltDependencies` list in the root `package.json` when `amazon-cognito-identity-js` was pulled in as a new dependency for this PR
- Without this, `pnpm install` on a fresh clone will warn/fail on the new dependency's install scripts
- All CI checks pass with this change (`turbo run lint && typecheck && test`, 14/14 tasks)

## Test plan

- [x] Ran `pnpm install` on the `t3code/claris-id-support` branch
- [x] Ran `pnpm run ci` — 14/14 tasks successful, zero failures
- [x] Ran Claris ID smoke test against `iasp.account.filemaker-cloud.com` — all 5 operations passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency management configuration to optimize build handling for specific packages requiring native compilation during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->