### PR TITLE
Split fmodata count flows

### DIFF
--- a/packages/fmodata/src/client/builders/select-utils.ts
+++ b/packages/fmodata/src/client/builders/select-utils.ts
@@ -6,7 +6,7 @@ const VALID_FIELD_NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9]*$/;
 /**
  * Determines if a field name needs to be quoted in OData queries.
  * Per FileMaker docs: field names with special characters (spaces, underscores, etc.) must be quoted.
- * Also quotes "id" as it's an OData reserved word.
+ * Also quotes "id"/"ID" as it's an OData reserved word.
  * Entity IDs (FMFID:*, FMTID:*) are not quoted as they're identifiers, not field names.
  *
  * @param fieldName - The field name or identifier to check
@@ -18,7 +18,7 @@ export function needsFieldQuoting(fieldName: string): boolean {
     return false;
   }
   // Always quote "id" as it's an OData reserved word
-  if (fieldName === "id") {
+  if (fieldName.toLowerCase() === "id") {
     return true;
   }
   // Quote if field name contains spaces, underscores, or other special characters

--- a/packages/fmodata/tests/filters.test.ts
+++ b/packages/fmodata/tests/filters.test.ts
@@ -46,6 +46,14 @@ import { contacts, users, usersTOWithIds } from "./utils/test-setup";
 describe("Filter Tests", () => {
   const client = new MockFMServerConnection();
   const db = client.database("fmdapi_test.fmp12");
+  const files = fmTableOccurrence(
+    "FILES",
+    {
+      ID: textField().primaryKey(),
+      s3key: textField(),
+    },
+    { defaultSelect: "all" },
+  );
 
   it("should enforce correct operator types for each field type", () => {
     // ✅ String operators
@@ -155,6 +163,12 @@ describe("Filter Tests", () => {
 
     const query2 = db.from(weirdTable).list().where(eq(weirdTable.id, "John"));
     expect(query2.getQueryString()).toContain(`$filter="id" eq 'John'`);
+  });
+
+  it("should quote uppercase ID in filters", () => {
+    const query = db.from(files).list().where(eq(files.ID, "abc"));
+
+    expect(query.getQueryString()).toContain(`$filter="ID" eq 'abc'`);
   });
 
   it("should support complex nested filters", () => {

--- a/packages/fmodata/tests/query-strings.test.ts
+++ b/packages/fmodata/tests/query-strings.test.ts
@@ -45,6 +45,14 @@ const contacts = fmTableOccurrence("contacts", {
   "special%char": textField(),
   "special&char": textField(),
 });
+const files = fmTableOccurrence(
+  "FILES",
+  {
+    ID: textField().primaryKey(),
+    s3key: textField(),
+  },
+  { defaultSelect: "all" },
+);
 
 describe("OData Query String Generation", () => {
   const client = new MockFMServerConnection();
@@ -142,6 +150,12 @@ describe("OData Query String Generation", () => {
       expect(selectPart).toBeDefined();
 
       expect(selectPart?.split(",")).toContain("name");
+    });
+
+    it("should quote uppercase ID in $select", () => {
+      const queryString = db.from(files).list().select({ ID: files.ID }).getQueryString();
+
+      expect(queryString).toContain('$select="ID"');
     });
   });
 


### PR DESCRIPTION
## Summary
- Split `count()` into two paths: `db.from(table).count()` now hits `/$count` and returns a number.
- Added `db.from(table).list().count()` for one-request list + total count responses as `{ records, count }`.
- Updated query typing, response handling, docs, and tests for the new behavior.
- Quoted uppercase `ID` field names in OData query generation.

## Testing
- Not run.
- Added/updated tests for batch queries, mocked responses, query strings, filters, e2e, and TypeScript types.
- Changeset added for `@proofkit/fmodata` minor release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened validation tests for field identifier quoting in filter expressions
  * Enhanced test coverage for query selection with uppercase identifiers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->