### PR TITLE
Quote uppercase ID fields in OData queries

### DIFF
--- a/.changeset/green-bulldogs-hunt.md
+++ b/.changeset/green-bulldogs-hunt.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/fmodata": patch
+---
+
+Quote reserved `ID` field names case-insensitively in OData selects and filters.

--- a/packages/fmodata/src/client/builders/select-utils.ts
+++ b/packages/fmodata/src/client/builders/select-utils.ts
@@ -6,7 +6,7 @@ const VALID_FIELD_NAME_REGEX = /^[a-zA-Z][a-zA-Z0-9]*$/;
 /**
  * Determines if a field name needs to be quoted in OData queries.
  * Per FileMaker docs: field names with special characters (spaces, underscores, etc.) must be quoted.
- * Also quotes "id" as it's an OData reserved word.
+ * Also quotes "id" case-insensitively as it's an OData reserved word.
  * Entity IDs (FMFID:*, FMTID:*) are not quoted as they're identifiers, not field names.
  *
  * @param fieldName - The field name or identifier to check
@@ -17,8 +17,8 @@ export function needsFieldQuoting(fieldName: string): boolean {
   if (fieldName.startsWith("FMFID:") || fieldName.startsWith("FMTID:")) {
     return false;
   }
-  // Always quote "id" as it's an OData reserved word
-  if (fieldName === "id") {
+  // Always quote "id" case-insensitively as it's an OData reserved word
+  if (fieldName.toLowerCase() === "id") {
     return true;
   }
   // Quote if field name contains spaces, underscores, or other special characters

--- a/packages/fmodata/tests/filters.test.ts
+++ b/packages/fmodata/tests/filters.test.ts
@@ -157,6 +157,19 @@ describe("Filter Tests", () => {
     expect(query2.getQueryString()).toContain(`$filter="id" eq 'John'`);
   });
 
+  it("should quote uppercase ID fields in filters", () => {
+    const files = fmTableOccurrence(
+      "FILES",
+      {
+        ID: textField().primaryKey(),
+        s3key: textField(),
+      },
+      { defaultSelect: "all" },
+    );
+    const query = db.from(files).list().where(eq(files.ID, "123"));
+    expect(query.getQueryString()).toContain(`$filter="ID" eq '123'`);
+  });
+
   it("should support complex nested filters", () => {
     const query = db
       .from(users)

--- a/packages/fmodata/tests/validation.test.ts
+++ b/packages/fmodata/tests/validation.test.ts
@@ -130,6 +130,22 @@ describe("Validation Tests", () => {
     expect(queryString).not.toContain("$expand");
   });
 
+  it("should quote uppercase ID fields in automatic selects", () => {
+    const files = fmTableOccurrence("FILES", {
+      ID: textField().primaryKey().notNull(),
+      s3key: textField().notNull(),
+    });
+    const mock = new MockFMServerConnection();
+    const db = mock.database("fmdapi_test.fmp12");
+    const query = db.from(files).list();
+
+    const queryString = query.getQueryString();
+
+    expect(queryString).toContain("$select=");
+    expect(queryString).toContain(`"ID"`);
+    expect(queryString).toContain("s3key");
+  });
+
   it("should skip validation if requested", async () => {
     const mock = new MockFMServerConnection();
     mock.addRoute({


### PR DESCRIPTION
## Summary
- Quote `ID` field names case-insensitively in OData select/filter generation.
- Add coverage for uppercase `ID` in filters and automatic selects.
- Include patch changeset for `@proofkit/fmodata`.

## Testing
- Not run
- Added/updated tests in `packages/fmodata/tests/filters.test.ts` and `packages/fmodata/tests/validation.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reserved OData field names like "ID" are now properly quoted case-insensitively in OData select and filter expressions, ensuring correct handling regardless of field name casing.

* **Tests**
  * Added test coverage validating proper quoting behavior for uppercase and reserved field names in OData query generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->