### PR TITLE
Add ProofKit v2 planning docs

### DIFF
--- a/apps/docs/planning/v2-next/examples-and-case-studies.md
+++ b/apps/docs/planning/v2-next/examples-and-case-studies.md
@@ -1,0 +1,22 @@
+# Examples and Case Studies (Deferred)
+
+**Status:** Deferred from v2 launch. Revisit for the next release.
+
+## What This Would Be
+
+Concrete, visible proof of what ProofKit produces. A first-time visitor to proofkit.dev currently sees a lot of abstract feature description but no real output. This asset would close that gap.
+
+Possible forms:
+
+- **Screenshot gallery** — finished WebViewer apps in context (kanban board, calendar, data grid, dashboard, etc.) shown next to the FileMaker layout they replaced
+- **Demo app** — a downloadable FileMaker file with a fully-built ProofKit WebViewer app inside, so developers can see the end state without building it first
+- **Before/after pages** — native FileMaker layout vs. the WebViewer replacement, with notes on what changed and why
+- **Customer case studies** — short write-ups of real projects: what they built, how long it took, what it replaced, what the outcome was
+
+## Why It's Deferred
+
+Production cost is high relative to launch timing. Screenshots need real apps; case studies need customer cooperation, write-up time, and approvals. The launch can ship without these by leaning on the getting-started videos for visible proof, and case studies can come later as launch customers produce material.
+
+## Why It Matters Long-Term
+
+Without concrete examples, the homepage relies on description. With them, it sells itself. Adding even one good case study after launch will measurably improve conversion.

--- a/apps/docs/planning/v2-next/index.md
+++ b/apps/docs/planning/v2-next/index.md
@@ -1,0 +1,8 @@
+# ProofKit v2-next — Deferred Items
+
+This folder collects content and capabilities that are valuable but **not in scope for the v2 launch**. Items here have been triaged out to keep launch focused. They should be revisited for the next release cycle.
+
+## Documents
+
+### [Examples and Case Studies](examples-and-case-studies.md)
+Concrete demos, screenshots, before/after comparisons, and customer stories. High value for landing page conversion, but production cost is too high for v2 launch timing.

--- a/apps/docs/planning/v2/alternatives.md
+++ b/apps/docs/planning/v2/alternatives.md
@@ -1,0 +1,37 @@
+# Alternatives and How ProofKit Compares
+
+A reasonable question from any first-time visitor: *why ProofKit, and not something else?* This document captures how we think about the alternatives a developer might consider, and where ProofKit fits among them.
+
+The lens we apply is the one in [First Principles](first-principles.md), particularly **[Agent First](first-principles.md#1-agent-first)** and **[Close the Loop for Agents](first-principles.md#3-close-the-loop-for-agents)**. Most existing approaches were designed for a pre-agentic world — they solve the problem of "a human writing WebViewer code." ProofKit is designed for a different problem: "an agent writing WebViewer code, and a human supervising." That difference shapes everything.
+
+## Hand-Rolled WebViewers
+
+The most common approach today: a developer writes HTML/JS by hand, figures out the bundling, and pastes the output into a FileMaker container or text field.
+
+This works, and many great apps have been built this way. What it doesn't do is close the loop for an agent. The agent has no direct access to your file's metadata, no automated way to deploy, no embedded browser to verify what it just wrote. Every iteration becomes a copy-paste cycle the developer has to drive. Pre-agentic approaches were built around the assumption that the human is the one iterating — that assumption no longer holds.
+
+## Pre-Agentic FileMaker Web Frameworks
+
+A handful of projects predate the current generation of coding agents. They typically provide a component library, a data-access pattern, and conventions for working inside a WebViewer. They were good answers to the problem they were designed for.
+
+The problem they were designed for is no longer the most important problem. Once an agent can write the code, what matters is whether the toolchain gives the agent the metadata, feedback, and deterministic deployment it needs to iterate to a correct result. That's where ProofKit invests — and it's not where pre-agentic frameworks were aimed.
+
+## Commercial Tools That Cover Similar Ground
+
+A few commercial products overlap with parts of what ProofKit does — schema access, deployment helpers, scaffolding. The differences worth noting:
+
+- **ProofKit is free.** See the [FAQ](faq-page.md#what-does-proofkit-cost). What you build with it is yours, and you don't need ProofKit installed to run the deployed apps.
+- **ProofKit is agent-first by design.** The whole toolchain is shaped around closing the loop for a coding agent rather than presenting a UI for a human to drive.
+- **ProofKit is open about what it's not.** We are explicit about what's in scope today and what isn't — see [Technical Requirements](technical-requirements.md#whats-out-of-scope-for-this-release).
+
+## Leaving FileMaker Entirely
+
+The other alternative on the table for many shops: rewrite the application from scratch in a modern stack — Next.js, Postgres, a hosted backend — and walk away from FileMaker.
+
+This is sometimes the right answer. It is also the answer with the highest cost and the highest risk. People trying to leap straight from FileMaker to a custom AI-built stack are running into real walls: databases getting deleted, codebases collapsing four to six months in. You also throw away everything FileMaker gives you for free — security model, multi-user database, scripting engine, file system access, printing — and have to rebuild each piece. See [Hybrid Apps](hyrid-apps.md) for what that "free" really amounts to.
+
+ProofKit's view: if leaving makes sense, leave — but do it in stages. Replace layouts with WebViewers first, then move to a separate web app with FileMaker as the backend, then if the economics still demand it, leave FileMaker. ProofKit is designed to support that whole path.
+
+## The Bottom Line
+
+The question isn't really "ProofKit vs. X." It's "what are you optimizing for?" If you want an agent to write WebViewer code well, with tight feedback loops and automated deployment, ProofKit is the toolchain built for that. If your needs are different — a hand-coded one-off, an existing investment in another framework — that's fine, and ProofKit can often accommodate alternative stacks anyway (see [Highlights — Stays Flexible When You Need It](hilights.md#5-stays-flexible-when-you-need-it)).

--- a/apps/docs/planning/v2/content-required-for-launch.md
+++ b/apps/docs/planning/v2/content-required-for-launch.md
@@ -59,10 +59,12 @@ A complete redo of the current ProofKit homepage at proofkit.dev. The new homepa
 
 - **Hero and value proposition** — drawn from [Highlights](hilights.md) and [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md)
 - **Feature narrative** — drawn from [Highlights — What ProofKit Does Well](hilights.md#what-proofkit-does-well)
-- **Hybrid app concept** — drawn from [Hybrid Apps](hyrid-apps.md)
+- **Hybrid app concept** — drawn from [Hybrid Apps](hyrid-apps.md), with the runtime diagram from [Data Flow](data-flow.md)
+- **"Why ProofKit?" / alternatives** — drawn from [Alternatives](alternatives.md)
+- **Pricing clarity** — "ProofKit is free" callout, drawn from the [FAQ](faq-page.md#what-does-proofkit-cost)
 - **FAQ section** — drawn from [FAQ](faq-page.md)
 - **Embedded getting started videos** — from the video series above
-- **Calls to action** — links to the Getting Started Guide, documentation, and GitHub
+- **Community and calls to action** — links to the Getting Started Guide, documentation, GitHub, and [community.proof.sh](https://community.proof.sh)
 
 The homepage should convey the core messages from [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md): you can code with agents in FileMaker, you can move in stages, and security comes built in.
 
@@ -106,3 +108,5 @@ A documentation page that details exactly what is required to use ProofKit. The 
 | Announcement Blog Post | Blog | [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md), [Highlights](hilights.md) |
 | FAQ Page | Docs | [FAQ](faq-page.md) |
 | Technical Requirements | Docs | [Technical Requirements](technical-requirements.md), [FAQ](faq-page.md) |
+| Data Flow / Architecture | Docs | [Data Flow](data-flow.md), [Hybrid Apps](hyrid-apps.md) |
+| Alternatives / "Why ProofKit?" | Docs / Web | [Alternatives](alternatives.md), [First Principles](first-principles.md) |

--- a/apps/docs/planning/v2/content-required-for-launch.md
+++ b/apps/docs/planning/v2/content-required-for-launch.md
@@ -1,0 +1,108 @@
+# Content Required for Launch
+
+This document defines the content assets we need to produce before ProofKit v2 goes public. It covers video, documentation, landing pages, and blog content. Each section describes what the asset is, what it covers, and where it fits in the overall launch.
+
+## Getting Started Video Series
+
+A four-part video series that walks a new user through the happy path from zero to deployed. These videos serve double duty: they are the backbone of the **Getting Started Guide** in the documentation, and they are standalone assets that can be embedded into landing pages and marketing material.
+
+### Video 1 — Download, Install, and Set Up
+
+The simplest possible on-ramp. This video covers:
+
+- Downloading and installing ProofKit
+- Connecting it to a FileMaker file
+- Getting the tool running and confirming the connection works
+
+No coding, no project creation — just get the tool installed and talking to your file. The goal is to show that setup is fast and straightforward. This directly demonstrates the [First Principles — Meet Developers Where They Are](first-principles.md#2-meet-developers-where-they-are--in-their-editor-of-choice) principle — developers stay in their own editor.
+
+### Video 2 — Explore Your Data in Chat Mode
+
+Before building anything, show what you get for free just by having the tool installed. This video covers:
+
+- Using chat mode to explore your FileMaker data
+- Asking questions about your schema — tables, fields, layouts, relationships
+- Generating charts and visualizations from your data on the fly
+
+This is the "chat over your data" experience. No WebViewer project, no code — just a developer having a conversation with an agent that understands their FileMaker file. It demonstrates [Highlights — Gives Agents Direct Access to Your FileMaker File](hilights.md#1-gives-agents-direct-access-to-your-filemaker-file) in the most approachable way possible.
+
+### Video 3 — Build a WebViewer Project with Claude Code
+
+Now we build something. This video switches from chat mode to agentic coding and covers:
+
+- Using Claude Code (not chat) to scaffold a new WebViewer project
+- Getting the project running in a browser with live preview
+- Building a UI that is connected to the FileMaker database
+- Seeing the full write → test → fix loop in action
+
+This is where the power of [closing the loop](first-principles.md#3-close-the-loop-for-agents) becomes visible — the agent writes code, sees the result, and iterates. The viewer gets to watch the agent self-correct its way to a working app.
+
+### Video 4 — Deploy to Your FileMaker File
+
+The final step: getting the finished app into the FileMaker file. This video covers:
+
+- Bundling the web app for deployment
+- Deploying the bundle into the FileMaker file
+- Verifying the deployed app works inside a WebViewer
+
+This demonstrates [Highlights — Automates Deployment Into Your FileMaker File](hilights.md#3-automates-deployment-into-your-filemaker-file) and closes the loop on the full developer workflow: install → explore → build → deploy.
+
+## Getting Started Guide
+
+A documentation page (or short series of pages) that mirrors the video series above. Each section corresponds to a video, with written steps, screenshots, and an embedded video. This is the primary entry point for new users in the docs.
+
+The guide draws from the same material as the videos but is designed to be followable without watching them — a developer should be able to work through the guide with just the text and screenshots.
+
+## Homepage Redesign
+
+A complete redo of the current ProofKit homepage at proofkit.dev. The new homepage will be built from the content library in this folder:
+
+- **Hero and value proposition** — drawn from [Highlights](hilights.md) and [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md)
+- **Feature narrative** — drawn from [Highlights — What ProofKit Does Well](hilights.md#what-proofkit-does-well)
+- **Hybrid app concept** — drawn from [Hybrid Apps](hyrid-apps.md)
+- **FAQ section** — drawn from [FAQ](faq-page.md)
+- **Embedded getting started videos** — from the video series above
+- **Calls to action** — links to the Getting Started Guide, documentation, and GitHub
+
+The homepage should convey the core messages from [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md): you can code with agents in FileMaker, you can move in stages, and security comes built in.
+
+## Announcement Blog Post
+
+A blog post published on the Proof website (proofgeist.com) announcing ProofKit v2 and linking to the proofkit.dev domain. This is the launch announcement — it should:
+
+- Explain what ProofKit v2 is and what's new
+- Highlight the key capabilities (agent-first development, feedback loops, deployment)
+- Link to the proofkit.dev homepage and Getting Started Guide
+- Position ProofKit within the broader story of where FileMaker development is heading
+
+Tone and messaging should follow the guardrails in [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md).
+
+## Documentation Pages
+
+### FAQ Page
+
+A public-facing FAQ page on proofkit.dev. Content is drawn from the internal [FAQ document](faq-page.md) in this folder, adapted for a public audience. Covers: what ProofKit is, what it produces, framework vs. tools, open source status, token costs, end-user requirements, WebDirect support, and other anticipated questions.
+
+### Technical Requirements Page
+
+A documentation page that details exactly what is required to use ProofKit. The internal source of truth is [Technical Requirements](technical-requirements.md) — the public page is adapted from that document. Covers:
+
+- **FileMaker versions** — FileMaker 22 or greater, with future releases tied to FileMaker 26
+- **AI coding environments** — Claude Code and Claude Desktop are tested at launch; broader MCP-compatible agents are the goal
+- **Supported runtime platforms** — FileMaker Pro (macOS, Windows), FileMaker Go (iOS/iPadOS), WebDirect
+- **Platform-specific notes** — any differences in capability or behavior across platforms (e.g., WebDirect refresh considerations noted in the [FAQ](faq-page.md))
+- **What's out of scope** — agentic editing of scripts, tables, and layouts is not in this release
+
+## Summary
+
+| Asset | Type | Primary Source Documents |
+|---|---|---|
+| Video 1 — Install & Set Up | Video | — |
+| Video 2 — Chat Mode | Video | [Highlights](hilights.md) |
+| Video 3 — Build a WebViewer | Video | [First Principles](first-principles.md), [Highlights](hilights.md) |
+| Video 4 — Deploy | Video | [Highlights](hilights.md) |
+| Getting Started Guide | Docs | Videos 1–4 |
+| Homepage Redesign | Web | All documents in this folder |
+| Announcement Blog Post | Blog | [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md), [Highlights](hilights.md) |
+| FAQ Page | Docs | [FAQ](faq-page.md) |
+| Technical Requirements | Docs | [Technical Requirements](technical-requirements.md), [FAQ](faq-page.md) |

--- a/apps/docs/planning/v2/data-flow.md
+++ b/apps/docs/planning/v2/data-flow.md
@@ -9,37 +9,37 @@ This document explains how data moves between FileMaker and a ProofKit WebViewer
 A ProofKit WebViewer app is a normal React app that happens to run inside a FileMaker WebViewer. The WebViewer hosts the HTML/JS bundle; the React app talks to FileMaker by calling FileMaker scripts and receiving structured data back.
 
 ```mermaid
-flowchart TD
+flowchart LR
     User([User])
-    subgraph FMClient["FileMaker Pro / Go / WebDirect"]
-        Layout["FileMaker Layout"]
-        WV["WebViewer<br/>(hosts the bundle)"]
-        React["React App<br/>(TanStack Query)"]
-        Script["FileMaker Script<br/>(secure backend)"]
-        DB[("FileMaker Database<br/>+ permissions")]
-        FS["File System / cURL /<br/>Printing / PDF"]
-    end
-    External[("External APIs<br/>(no CORS)")]
 
-    User -->|interacts| Layout
-    Layout --> WV
-    WV --> React
-    React -->|FileMaker.PerformScript<br/>with parameter| Script
-    Script -->|reads/writes| DB
-    Script -->|cURL / file ops| FS
-    Script -->|HTTP| External
-    Script -->|FileMaker.PerformScriptResult| React
-    React -->|renders UI| WV
-    DB -.->|permissions inherited| Script
+    subgraph FMFile["FileMaker File"]
+        Script{{"FileMaker<br/>Scripts"}}
+        WV["WebViewer<br/>(React App)"]
+        HTML["html bundle"]
+        DB[("FM Database")]
+        Print["Printing, etc."]
+        FS["File System"]
+        APIs["External APIs"]
+
+        HTML --> WV
+        WV <--> Script
+        Script <--> DB
+        Script --> Print
+        Script --> FS
+        Script -->|"No CORS issues"| APIs
+        WV --> APIs
+    end
+
+    User <--> WV
 ```
 
 ## The Pieces
 
-- **The user** interacts with a FileMaker layout that contains a WebViewer.
-- **The WebViewer** hosts the bundled HTML/JS — the React app deployed by ProofKit.
-- **The React app** uses TanStack Query to manage server state and trigger calls to FileMaker.
-- **FileMaker scripts** are the secure back end. Anything the script can do, the web app can now do — read/write the database, make CORS-free network requests, access the file system, generate PDFs.
+- **The user** interacts with the WebViewer directly.
+- **The WebViewer** hosts the bundled HTML/JS — the React app deployed by ProofKit. It uses TanStack Query to manage server state and trigger calls into FileMaker.
+- **FileMaker scripts** are the secure back end and the hub of the diagram. Anything a script can do, the web app can now do — read/write the database, access the file system, print, generate PDFs, make network requests.
 - **The database** enforces the user's privilege set. The script runs with the user's permissions, so authorization is inherited rather than re-implemented.
+- **External APIs** can be reached two ways: directly from the WebViewer (subject to CORS, with any secrets exposed to the browser) or through a script (no CORS, secrets stay in FileMaker). The script path is the reason this architecture matters.
 
 ## Why This Matters
 

--- a/apps/docs/planning/v2/data-flow.md
+++ b/apps/docs/planning/v2/data-flow.md
@@ -1,0 +1,51 @@
+# Data Flow
+
+This document explains how data moves between FileMaker and a ProofKit WebViewer app at runtime. It's a companion to [Hybrid Apps](hyrid-apps.md) — that document explains *why* the hybrid model is powerful, this one explains *how* the pieces fit together.
+
+> **Note:** The diagram below is a working draft. The shape is right, but the specific call names and flows may need refinement.
+
+## The Round Trip
+
+A ProofKit WebViewer app is a normal React app that happens to run inside a FileMaker WebViewer. The WebViewer hosts the HTML/JS bundle; the React app talks to FileMaker by calling FileMaker scripts and receiving structured data back.
+
+```mermaid
+flowchart TD
+    User([User])
+    subgraph FMClient["FileMaker Pro / Go / WebDirect"]
+        Layout["FileMaker Layout"]
+        WV["WebViewer<br/>(hosts the bundle)"]
+        React["React App<br/>(TanStack Query)"]
+        Script["FileMaker Script<br/>(secure backend)"]
+        DB[("FileMaker Database<br/>+ permissions")]
+        FS["File System / cURL /<br/>Printing / PDF"]
+    end
+    External[("External APIs<br/>(no CORS)")]
+
+    User -->|interacts| Layout
+    Layout --> WV
+    WV --> React
+    React -->|FileMaker.PerformScript<br/>with parameter| Script
+    Script -->|reads/writes| DB
+    Script -->|cURL / file ops| FS
+    Script -->|HTTP| External
+    Script -->|FileMaker.PerformScriptResult| React
+    React -->|renders UI| WV
+    DB -.->|permissions inherited| Script
+```
+
+## The Pieces
+
+- **The user** interacts with a FileMaker layout that contains a WebViewer.
+- **The WebViewer** hosts the bundled HTML/JS — the React app deployed by ProofKit.
+- **The React app** uses TanStack Query to manage server state and trigger calls to FileMaker.
+- **FileMaker scripts** are the secure back end. Anything the script can do, the web app can now do — read/write the database, make CORS-free network requests, access the file system, generate PDFs.
+- **The database** enforces the user's privilege set. The script runs with the user's permissions, so authorization is inherited rather than re-implemented.
+
+## Why This Matters
+
+Two properties fall out of this architecture:
+
+1. **Secrets stay in FileMaker.** API keys, credentials, and sensitive logic live inside scripts. Browser code never sees them.
+2. **The web app inherits everything FileMaker can do.** Printing, file system access, native cURL, plugins — all reachable through a script call.
+
+For deeper coverage of these advantages, see [Hybrid Apps — Advantages Over Browser-Only Apps](hyrid-apps.md#advantages-over-browser-only-apps).

--- a/apps/docs/planning/v2/faq-page.md
+++ b/apps/docs/planning/v2/faq-page.md
@@ -39,7 +39,7 @@ It's not currenlty, but it might be that ProofChat gets repackaged as ProofKit c
 
 ## Can ProofKit enable agentic editing of scripts or tables
 
-This release is targeted at building UI components. We want to be able to support scripts and other FileMaker elements, but it's challenging. We are working with Claris to suggest ways that this might get easier. We may enable some experimental features to try these types of operations if we can.
+This release is targeted at building UI components. We want to be able to support scripts and other FileMaker elements, but it's challenging. We are working with Claris to suggest ways that this might get easier. We may enable some experimental features to try these types of operations if we can. For the full scope of what's in and out of this release, see [Technical Requirements — What's Out of Scope for This Release](technical-requirements.md#whats-out-of-scope-for-this-release).
 
 ## Do the users of my ProofKit coded app need to have proofkit installed?
 
@@ -47,4 +47,4 @@ No. What get's installed is just for developer mode. After the application is bu
 
 ## Does Proofkit work in WebDirect.
 
-You will need FileMaker Pro to agentically code your FileMaker application. Once the application is bundled and deployed into FileMaker, it will work in WebDirect, but there are some special things you will need to do do make sure that refreshing the windows doesn't disrupt your users.  We will have more information on that soon.
+You will need FileMaker Pro to agentically code your FileMaker application. Once the application is bundled and deployed into FileMaker, it will work in WebDirect, but there are some special things you will need to do do make sure that refreshing the windows doesn't disrupt your users.  We will have more information on that soon. For the full list of supported runtime environments and FileMaker version requirements, see [Technical Requirements](technical-requirements.md).

--- a/apps/docs/planning/v2/faq-page.md
+++ b/apps/docs/planning/v2/faq-page.md
@@ -1,0 +1,50 @@
+# ProofKit FAQ
+
+## What is ProofKit?
+
+ProofKit is an opinionated suite of tools that enables agentic development inside FileMaker. Its core purpose is to let developers use AI agents (Claude Code, Cursor, Codex, etc.) to build web apps that run inside FileMaker WebViewers — or that use FileMaker as a backend.
+
+It bundles our opinions on the modern web stack — TypeScript, React, Tailwind, shadcn/ui, Vite or Next.js — so you don't have to make those decisions yourself. It includes AI skills that teach the agent how to pull data from a FileMaker backend, whether that's via a FileMaker script (when running in a WebViewer), OData, or the Data API. For the full stack details, see [Highlights — Ships an Opinionated, Battle-Tested Stack](hilights.md#4-ships-an-opinionated-battle-tested-stack).
+
+Two technical pieces make agentic coding in FileMaker actually work:
+
+1. The agent can read metadata from the FileMaker file — field names, script names, layout names, etc.
+2. The agent can inspect the WebViewer output, read errors, take screenshots, and self-correct. Closing that feedback loop is what makes the whole thing viable.
+
+These are direct expressions of the [Agent First](first-principles.md#1-agent-first) and [Close the Loop](first-principles.md#3-close-the-loop-for-agents) principles.
+
+## What does ProofKit produce — web apps for FileMaker, or WebViewer apps?
+
+Both. We're starting with a focus on WebViewers, but we see a natural progression: WebViewer → web app with FileMaker backend → eventually moving off FileMaker entirely if that makes sense for the customer. As Eric Luce put it: it's always a web app, it's just that sometimes the web app is running inside a WebViewer. For why we start with WebViewers, see [First Principles — Start Where the On-Ramp Is Easiest](first-principles.md#4-start-where-the-on-ramp-is-easiest-webviewers). For what makes a WebViewer app uniquely powerful, see [Hybrid Apps](hyrid-apps.md).
+
+## Is ProofKit a framework or a collection of tools?
+
+It's a collection of tools. The primary goal is to enable agentic development in FileMaker, and ProofKit is the toolset that makes that happen. See [First Principles](first-principles.md) for what guides what we build and what we don't.
+
+## Is the new ProofKit replacing proofkit.dev?
+
+It's both a replacement and an expansion. ProofKit started before agents were really a thing — this new version is ProofKit, but with agents. We're consolidating everything under one brand: no more ProofKit MCP vs. ProofKit AI vs. ProofKit dev. It's all just ProofKit. The new release will include an MCP server, command-line capabilities, and support for everything the previous version supported.
+
+## Is ProofKit going to remain open source?
+
+The proofkit.dev website and the public GitHub repo will remain open source. The MCP server and other components we want to maintain in closed source will live in a separate repo.
+
+## Is token cost a real concern?
+
+Yes. AI inference is currently being heavily subsidized by Anthropic, OpenAI, and others — we're paying a fraction of what it actually costs to run. That will eventually have to correct. We hope that competition from open source and local models will keep the prices within a range were the value is clear.
+
+## How is this related to ProofChat?
+
+It's not currenlty, but it might be that ProofChat gets repackaged as ProofKit component in the future.
+
+## Can ProofKit enable agentic editing of scripts or tables
+
+This release is targeted at building UI components. We want to be able to support scripts and other FileMaker elements, but it's challenging. We are working with Claris to suggest ways that this might get easier. We may enable some experimental features to try these types of operations if we can.
+
+## Do the users of my ProofKit coded app need to have proofkit installed?
+
+No. What get's installed is just for developer mode. After the application is built and bundled into your application, all they need is FileMaker
+
+## Does Proofkit work in WebDirect.
+
+You will need FileMaker Pro to agentically code your FileMaker application. Once the application is bundled and deployed into FileMaker, it will work in WebDirect, but there are some special things you will need to do do make sure that refreshing the windows doesn't disrupt your users.  We will have more information on that soon.

--- a/apps/docs/planning/v2/faq-page.md
+++ b/apps/docs/planning/v2/faq-page.md
@@ -29,13 +29,39 @@ It's both a replacement and an expansion. ProofKit started before agents were re
 
 The proofkit.dev website and the public GitHub repo will remain open source. The MCP server and other components we want to maintain in closed source will live in a separate repo.
 
+## What does ProofKit cost?
+
+**ProofKit is free.** It's a tool — like a hammer. Apps you build with ProofKit are yours. You can do whatever you want with them. You don't need ProofKit installed to run the apps you build with it; the deployed bundle is just HTML and JavaScript living in your FileMaker file.
+
+The cost you do pay is for the AI agent itself (Claude Code subscription, OpenAI API usage, etc.) — that's between you and your AI provider, not us.
+
 ## Is token cost a real concern?
 
 Yes. AI inference is currently being heavily subsidized by Anthropic, OpenAI, and others — we're paying a fraction of what it actually costs to run. That will eventually have to correct. We hope that competition from open source and local models will keep the prices within a range were the value is clear.
 
-## How is this related to ProofChat?
+## What happens when the agent generates bad code?
 
-It's not currenlty, but it might be that ProofChat gets repackaged as ProofKit component in the future.
+ProofKit ships with a lot of guardrails specifically to keep agents on track — see [First Principles — Close the Loop for Agents](first-principles.md#3-close-the-loop-for-agents) and [Highlights — Closes the Loop Between Writing, Testing, and Fixing](hilights.md#2-closes-the-loop-between-writing-testing-and-fixing). Linters, type checks, type generators from your FileMaker schema, and an embedded browser that lets the agent see runtime errors all combine to let the agent self-correct most mistakes without you intervening.
+
+When you do need to dig in yourself, the project includes the standard web devtools — including TanStack Query devtools — so you can inspect state and network calls just like in any modern web project.
+
+To be clear: ProofKit doesn't make you a senior engineer. It gets you started on your coding journey, and if you're already advanced it makes you more productive.
+
+## Can I migrate apps built with an older version of ProofKit to v2?
+
+The deployed apps themselves are just HTML and JavaScript living in your FileMaker file — they will continue to work as-is. There's nothing to migrate on the runtime side.
+
+What changes between versions is the **developer tooling** — the MCP server, CLI, and skills you use to build new apps or modify existing ones. Future Claris releases may unlock new ProofKit features that depend on newer FileMaker versions, but older deployed apps will continue to run.
+
+## How does multi-developer / team workflow work?
+
+For the **FileMaker file** itself, ProofKit doesn't change anything. FileMaker has never had a shared development model that doesn't involve developers working against a shared file hosted on a server. That's still how it works. It may be solved in the future, but it isn't yet.
+
+For the **web code**, you have all the normal options. The ProofKit project is just a web project — you can put it on GitHub, use branches and pull requests, run CI, and follow whatever SDLC your team prefers.
+
+## Where do I get help?
+
+The community lives at [community.proof.sh](https://community.proof.sh). That's the place for questions, sharing what you've built, and getting unstuck.
 
 ## Can ProofKit enable agentic editing of scripts or tables
 

--- a/apps/docs/planning/v2/first-principles.md
+++ b/apps/docs/planning/v2/first-principles.md
@@ -1,0 +1,66 @@
+# First Principles
+
+These are the principles that guide what we build, what we don't build, and where we focus our effort. They explain not just what ProofKit is today, but why it is shaped the way it is.
+
+## 1. Agent First
+
+Our number one focus is creating systems that **coding agents can work with effectively inside FileMaker.** Everything else flows from this.
+
+The most important feature ProofKit brings is the ability for agents to write FileMaker WebViewer applications well — to read the file, generate code that fits, deploy it, and verify the result. For the concrete capabilities this enables, see [ProofKit Highlights — What ProofKit Does Well](hilights.md#what-proofkit-does-well).
+
+A direct consequence of "agent first" is what we are *not* building, at least for now: **our own coding editor or agent.** The first thing we're doing is enabling whatever coding agent people are already using to code effectively inside FileMaker. (See also: [FAQ — Is ProofKit a framework or a collection of tools?](faq-page.md#is-proofkit-a-framework-or-a-collection-of-tools))
+
+## 2. Meet Developers Where They Are — In Their Editor of Choice
+
+People will have a coding editor they prefer, and the ecosystem incentives push hard in that direction:
+
+- **Subscriptions lock in tools.** If a developer has a Claude Code Max subscription, they're going to use Claude Code rather than reach for an editor that requires them to bring their own API key and pay per token.
+- **The leading agents are genuinely good.** Claude Code, Cursor, Codex, OpenCode, and others all have deep, sophisticated understanding of how to write code. Reproducing a custom editor that competes with them — and that's also tailored to FileMaker — would be a massive undertaking.
+- **Editors are integrated with broader workflows.** Developers' editors are wired into their other tools and habits. Asking them to switch is asking a lot.
+
+So we strongly believe the first move is to **support the coding editors developers are already using**, not to build a new one. It's the most flexible way forward and the fastest way to deliver value. This is also a core part of our public messaging — see [What We Want FM Devs to Hear — You can code with agents in FileMaker](what-want-fm-devs-to-feel.md#you-can-code-with-agents-in-filemaker).
+
+## 3. Close the Loop for Agents
+
+This is the practical corollary of "agent first." An agent without feedback is an agent that hallucinates. An agent *with* good feedback can iterate its way to a correct solution.
+
+Closing the loop means: when an agent attempts a task and gets it wrong, the system provides clear, actionable feedback so it can fix its own mistakes.
+
+In ProofKit, this shows up as:
+
+- **Strong browser automation**, so agents can drive the actual UI, read console errors, take screenshots, and verify behavior end to end.
+- **Tools that return useful errors.** When something fails, the error message is designed to tell the agent what went wrong and what to try next — not just that something failed.
+- **Deterministic feedback channels** wherever possible: linters, type checks, validators that produce consistent, machine-readable signals.
+
+Iteration is where the real power of agentic coding comes from. Closing the loop is what makes iteration possible. For the specific feedback channels ProofKit provides, see [Highlights — Closes the Loop Between Writing, Testing, and Fixing](hilights.md#2-closes-the-loop-between-writing-testing-and-fixing).
+
+## 4. Start Where the On-Ramp Is Easiest: WebViewers
+
+FileMaker WebViewers are the easiest entry point into this space, and that's where we're starting.
+
+When you build a WebViewer app, a lot of hard problems are already solved for you:
+
+- **Security** is inherited from FileMaker
+- **The database** is already there
+- **Deployment** is just bundling code into the file
+- **Auth, multi-user access, permissions** — all handled
+
+This connects directly to our concept of **hybrid apps** (see [hyrid-apps.md](hyrid-apps.md)). A WebViewer app is a hybrid app, and hybrid apps are uniquely powerful — combining modern web UI with FileMaker's platform-level capabilities. That's a great place to start, and a great place to stay for a large class of applications.
+
+## 5. Full Web Apps Are Coming, Too
+
+WebViewers are the starting point, not the ceiling. Work is already underway to make ProofKit equally good at building **full web apps backed by FileMaker** — apps that run in a regular browser and talk to FileMaker over OData, the Data API, or other server-side technologies.
+
+These capabilities aren't surfaced yet, but we're building toward them. The natural progression is: WebViewer → web app with a FileMaker back end → eventually moving off FileMaker entirely if and when that makes sense for the customer. ProofKit is designed to support that whole path. This progression is also central to our messaging — see [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md#you-can-code-with-agents-in-filemaker) and [FAQ — What does ProofKit produce?](faq-page.md#what-does-proofkit-produce--web-apps-for-filemaker-or-webviewer-apps)
+
+## 6. Deployed Code Should Behave Like FileMaker Code
+
+A guiding goal: the HTML and JavaScript we deploy into a FileMaker app should **live in the FileMaker file the way other FileMaker assets live in the file** — as part of the schema and catalog, not as data sitting in a record.
+
+In the currently shipping version of FileMaker (as of this writing), this isn't fully possible — bundled artifacts are stored in a dedicated table/field. That works, but it's not where this kind of code belongs. Deployed code should be a first-class part of the file's structure, version-controlled, inspectable, and managed alongside scripts, layouts, and tables.
+
+We're working actively to improve this, both in ProofKit and in conversation with Claris. Future releases will move bundled output out of data records and into the file schema itself, so HTML code behaves like the other code in your FileMaker app.
+
+## The Through-Line
+
+Each of these principles points the same direction: **make it as easy as possible for agents and the developers who use them to build great applications inside FileMaker, using the tools they already have, with feedback loops tight enough to actually iterate to a working result.** Everything we build is in service of that.

--- a/apps/docs/planning/v2/hilights.md
+++ b/apps/docs/planning/v2/hilights.md
@@ -1,0 +1,95 @@
+# ProofKit Highlights
+
+ProofKit is the product of years of building FileMaker web applications — both for WebViewers and standalone browsers — and, more recently, of building those applications with AI coding agents. The release of **ProofKit MCP** brings everything we've learned into a single, opinionated toolkit that unlocks agentic coding for FileMaker.
+
+## Why Build With WebViewers
+
+Before talking about ProofKit, it's worth being clear about why WebViewers are such a powerful target for improving a FileMaker system in the first place. WebViewers are where we start because the on-ramp is easiest — see [First Principles — Start Where the On-Ramp Is Easiest](first-principles.md#4-start-where-the-on-ramp-is-easiest-webviewers). For a deeper look at what a WebViewer-based app actually gives you, see [Hybrid Apps](hyrid-apps.md).
+
+### Break Free of FileMaker's Limited UI Canvas
+
+Native FileMaker layouts give you a relatively small set of components. FileMaker developers are famously creative at squeezing more out of them, but you're still working inside hard limits. Modern UI patterns either look dated on a native layout or simply don't exist:
+
+- Kanban boards
+- Full-featured calendars
+- Accordions and disclosure panels
+- Data grids with sorting, filtering, and resizable columns
+- Rich date and time pickers
+- Charting and data visualization
+
+With web technology in a WebViewer, **anything you can build on the web you can render on a FileMaker layout**. The UI ceiling effectively disappears.
+
+### Reduce Calculation Load and Improve Performance
+
+A lot of FileMaker UI behavior — show/hide, conditional formatting, enable/disable, filtered portals, sortable portal headers — is built with layout calculations, field calculations, or unstored calculations. These workarounds can put real strain on the database: unstored calculations may walk many records to produce a single visual effect, which gets slow fast.
+
+A WebViewer UI can:
+
+- Move presentation logic out of unstored calculations and into the browser, where it's cheap
+- Implement filtering, sorting, and conditional rendering instantly on the client
+- Reduce the work the FileMaker engine has to do to draw a screen
+
+The result is often a layout — and a system — that performs better, not just looks better.
+
+## Why ProofKit Exists
+
+Coding agents need **deterministic feedback** to write code that works. Without it, you (the developer) end up doing the tedious work of copying metadata out of FileMaker, pasting errors back into your editor, and shepherding the agent through trial and error. Agents are actually better than humans at consuming this kind of structured information — provided they can get to it. ProofKit gives them that access. This is the "agent first" and "close the loop" principles in action — see [First Principles](first-principles.md#1-agent-first).
+
+## What ProofKit Does Well
+
+### 1. Gives Agents Direct Access to Your FileMaker File
+
+Through the ProofKit MCP server, coding agents can explore your FileMaker file directly:
+
+- List layouts and the fields on each layout
+- Read tables and table fields
+- Get script names
+- Read value lists and value list items
+- Access the metadata they need to generate code that actually fits your file
+
+No more copy-paste of XML or DDR exports.
+
+### 2. Closes the Loop Between Writing, Testing, and Fixing
+
+Agents don't just write code — they verify it. ProofKit closes the loop with multiple feedback channels:
+
+- **Linters and formatters** built in
+- **Deterministic quality gates** that check validity
+- **TypeScript and React** — well understood by LLMs
+- **Type generators** so agents know the shape of your data
+- **Embedded browsers** so agents can navigate the app, see the rendered UI, and read console errors
+
+When something is broken — a missing field, a runtime error, a UI defect — the agent sees it and self-corrects. This is the critical unlock for agentic coding in FileMaker.
+
+### 3. Automates Deployment Into Your FileMaker File
+
+The MCP server bundles your HTML, optimizes it for FileMaker WebViewers, and deploys it into the file. In the current release, bundled artifacts are stored in a dedicated table/field; future releases will remove that requirement — see [First Principles — Deployed Code Should Behave Like FileMaker Code](first-principles.md#6-deployed-code-should-behave-like-filemaker-code). Either way, the deployment details are handled for you — no manual bundling, no manual placement.
+
+### 4. Ships an Opinionated, Battle-Tested Stack
+
+You don't have to choose a bundler, a framework, a UI library, a router, or a data layer. ProofKit comes with:
+
+- **React + TypeScript** as the foundation
+- **shadcn/ui** for beautiful, tweakable components
+- **Dark and light mode** out of the box
+- **Multi-page routing** so a single bundle can host customers, invoices, dashboards, detail views, etc., with sidebar or top navigation
+- **TanStack Query** for intelligent caching and keeping the UI in sync with FileMaker server data — without hammering the server and without manual refreshes
+
+Everything is integrated and known to work together.
+
+### 5. Stays Flexible When You Need It
+
+The happy path is the opinionated stack — fastest way to a working app, especially if you're newer to web development. But if you've already invested in a different stack (Svelte, Vue, etc.), ProofKit can accommodate it. We'll make alternative stacks easier over time.
+
+## The Bottom Line
+
+Without ProofKit, building an agentic FileMaker WebViewer app means:
+
+- Hand-copying metadata from FileMaker into your editor
+- Hand-copying errors back the other way
+- Choosing and wiring up a bundler, framework, UI library, router, and data layer yourself
+- Figuring out how to bundle and deploy HTML into your file correctly, every time
+
+With ProofKit, the agent reads the file, writes the code, tests it in a real browser, fixes its own mistakes, and ships the result into your FileMaker file. You stay focused on the application — not the plumbing.
+
+For common questions about what ProofKit is and how it fits, see the [FAQ](faq-page.md). For the advantages a hybrid WebViewer app gives you over a pure browser app, see [Hybrid Apps](hyrid-apps.md).

--- a/apps/docs/planning/v2/hilights.md
+++ b/apps/docs/planning/v2/hilights.md
@@ -92,4 +92,4 @@ Without ProofKit, building an agentic FileMaker WebViewer app means:
 
 With ProofKit, the agent reads the file, writes the code, tests it in a real browser, fixes its own mistakes, and ships the result into your FileMaker file. You stay focused on the application — not the plumbing.
 
-For common questions about what ProofKit is and how it fits, see the [FAQ](faq-page.md). For the advantages a hybrid WebViewer app gives you over a pure browser app, see [Hybrid Apps](hyrid-apps.md).
+For common questions about what ProofKit is and how it fits, see the [FAQ](faq-page.md). For the advantages a hybrid WebViewer app gives you over a pure browser app, see [Hybrid Apps](hyrid-apps.md). For how these capabilities translate into launch content — videos, guides, and the homepage — see [Content Required for Launch](content-required-for-launch.md).

--- a/apps/docs/planning/v2/hyrid-apps.md
+++ b/apps/docs/planning/v2/hyrid-apps.md
@@ -1,0 +1,79 @@
+# Hybrid Apps
+
+## What Is a Hybrid App?
+
+A hybrid app is a FileMaker application that uses web technology rendered inside WebViewers for some or all of its UI, while still leveraging the full power of the FileMaker platform underneath. It's not just a database with a web front end — it's a web app that inherits everything FileMaker can do. This is where ProofKit starts — see [First Principles — Start Where the On-Ramp Is Easiest](first-principles.md#4-start-where-the-on-ramp-is-easiest-webviewers).
+
+The key unlock is simple: **a WebViewer app can call any FileMaker script.** Anything a FileMaker script can do, your web app can now do. This gives you the best of both worlds — you build your UI with the best tools for building UI, and you retain all of FileMaker's scripting, business logic, and platform-level access.
+
+## Think of It as Multi-User Electron
+
+If you're familiar with [Electron](https://www.electronjs.org/), a FileMaker hybrid app will feel familiar. Electron is the cross-platform application framework behind Slack, VS Code, Figma, Discord, and countless other desktop apps. Electron apps render web technology in a native shell and give that web code privileged access to the underlying machine — file system, network, native dialogs, OS integrations.
+
+A FileMaker hybrid app does essentially the same thing: web UI in a shell, with privileged access to the host machine through FileMaker scripts.
+
+The crucial difference: **a FileMaker hybrid app is multi-user by default.** Electron, on its own, is just a shell — if you want multiple users sharing data, you have to build that yourself: stand up a back-end database, write a syncing engine, handle conflicts, manage authentication, deploy and operate servers. FileMaker gives you all of that out of the box. Shared data, record locking, user accounts, permissions, server-side scripting — built in.
+
+So a FileMaker hybrid app is, in effect, **Electron with a multi-user database, security model, and back end included.**
+
+## Advantages Over Browser-Only Apps
+
+### Inherited Security
+
+When a user is logged into a FileMaker file, they bring their FileMaker permissions with them. A hybrid app inherits all of that:
+
+- The user's privilege set controls what they can see and do
+- You can read those permissions inside the WebViewer and use them to drive your app's own authorization logic
+- No separate auth system to build or maintain — FileMaker's security model is your security model
+
+### A Built-In Secure Back End
+
+Because your web app can call FileMaker scripts, those scripts act as a secure back end:
+
+- Scripts can read encrypted data and decrypt it without exposing secrets to browser code
+- You can work with API keys, credentials, and sensitive business logic inside scripts — none of it reaches the client
+- This is a significant advantage over a pure browser app, where secrets are notoriously hard to protect
+
+### CORS-Free Network Access
+
+FileMaker has its own implementation of cURL, which means network requests from scripts are not subject to browser CORS policies. You can:
+
+- Call any external API without CORS restrictions
+- Use FileMaker's native cURL or higher-level abstractions like `fetch` built on top of it
+- Reach services and endpoints that a browser would block
+
+### File System Access
+
+FileMaker inherits the logged-in user's file system privileges on their Mac or Windows machine. A hybrid app can:
+
+- Read and write files anywhere the user has access — documents, preferences, temp directories, desktop
+- Open native file pickers to let users choose files, then pass those files back into the WebViewer
+- Work with the file system in ways that browsers simply cannot
+
+### Printing and PDF Generation
+
+FileMaker's printing capabilities have always been a strength, and hybrid apps get them for free:
+
+- Use FileMaker's page setup and print engine
+- Print FileMaker layouts, including subsummary reports — something that remains genuinely difficult with web technologies alone
+- Save layouts as PDFs
+- Build multi-page PDFs by appending pages programmatically with FileMaker scripts
+- Generate PNGs or PDFs from within the WebViewer (charts, visualizations, etc.), pass them out to a FileMaker script, place them in a global field on a layout, and then incorporate them into a larger PDF or print job
+
+The round-trip between WebViewer-generated content and FileMaker's PDF/print engine is a powerful combination.
+
+### Plugin SDK as an Escape Hatch
+
+FileMaker's plugin SDK lets you write C/C++ extensions that can do virtually anything:
+
+- Direct access to ports, Bluetooth, and hardware interfaces
+- Network access beyond what browsers allow
+- Integration with native OS capabilities
+
+Some of these are technically possible from a browser, but many are not. And now that AI can help developers write FileMaker plugins, this escape hatch is becoming increasingly practical — it gives hybrid apps access to capabilities that would be extremely challenging from a standard web application.
+
+## The Bottom Line
+
+Hybrid apps let you build modern, rich UI with the best web technologies while retaining everything that makes FileMaker powerful: its security model, its scripting engine, its file system access, its printing and PDF capabilities, and its extensibility through plugins. You don't have to choose between a great UI and a capable platform — you get both.
+
+For the concrete tools that make building hybrid apps fast and agent-friendly, see [Highlights — What ProofKit Does Well](hilights.md#what-proofkit-does-well). For the natural progression beyond hybrid apps to full web apps and beyond, see [First Principles — Full Web Apps Are Coming, Too](first-principles.md#5-full-web-apps-are-coming-too) and [FAQ — What does ProofKit produce?](faq-page.md#what-does-proofkit-produce--web-apps-for-filemaker-or-webviewer-apps)

--- a/apps/docs/planning/v2/hyrid-apps.md
+++ b/apps/docs/planning/v2/hyrid-apps.md
@@ -62,6 +62,10 @@ FileMaker's printing capabilities have always been a strength, and hybrid apps g
 
 The round-trip between WebViewer-generated content and FileMaker's PDF/print engine is a powerful combination.
 
+### Works Offline
+
+Apps built with ProofKit work great offline — both in **FileMaker Pro** (with a local file) and in **FileMaker Go**. The WebViewer bundle ships inside the FileMaker file itself, so there's no server to call out to for the UI, and the local FileMaker engine handles data, scripting, and storage. Pure browser apps cannot match this without significant additional engineering (service workers, sync layers, conflict resolution). Hybrid apps get it for free.
+
 ### Plugin SDK as an Escape Hatch
 
 FileMaker's plugin SDK lets you write C/C++ extensions that can do virtually anything:

--- a/apps/docs/planning/v2/index.md
+++ b/apps/docs/planning/v2/index.md
@@ -28,6 +28,9 @@ Deep dive on what a hybrid FileMaker app actually is and why it's powerful. The 
 ### [Data Flow](data-flow.md)
 How data actually moves between FileMaker and a ProofKit WebViewer app at runtime. Includes a Mermaid diagram of the round-trip between the React app, FileMaker scripts, the database, and external systems. This is the document to draw from when developers ask "how does this actually work under the hood?" — pairs naturally with [Hybrid Apps](hyrid-apps.md).
 
+### [Tech Stack](tech-stack.md)
+The inventory of pieces that make up a ProofKit-generated application — React, TypeScript, shadcn/ui, Tailwind, Vite, TanStack Query and Router, ProofKit FMDAPI and TypeGen, FMFetch, plus the skills, tests, and project setup that keep agents on track. Explains what each piece does and why it was chosen. This is the document to draw from when developers ask "what exactly does ProofKit set up for me?"
+
 ### [Alternatives](alternatives.md)
 How ProofKit compares to other ways of solving the same problem: hand-rolled WebViewers, pre-agentic FileMaker web frameworks, commercial tools, and leaving FileMaker entirely. Framed through the lens of agent-first design and closing the loop. This is the document to draw from when answering "why ProofKit and not X?" on the homepage, FAQ, or in sales conversations.
 

--- a/apps/docs/planning/v2/index.md
+++ b/apps/docs/planning/v2/index.md
@@ -1,0 +1,38 @@
+# ProofKit v2 — Content Library Index
+
+This folder contains the internal source-of-truth documents for ProofKit v2. These documents capture our thinking, positioning, and messaging. They are not meant to be published directly — they are the content library we draw from when designing landing pages, documentation, and marketing materials for the public site.
+
+## Overview
+
+ProofKit is a suite of tools that enables agentic development inside FileMaker. It lets developers use the AI coding agents they already have (Claude Code, Cursor, Codex, etc.) to build web apps that run inside FileMaker WebViewers — or as standalone web apps backed by FileMaker. The agent reads the FileMaker file, writes code, tests it in a real browser, fixes its own mistakes, and deploys the result. ProofKit provides the metadata access, feedback loops, opinionated stack, and deployment tooling that make this work.
+
+The key themes across all documents:
+
+- **Agent first** — everything is designed so coding agents can work effectively inside FileMaker
+- **Close the loop** — agents need deterministic feedback to self-correct; ProofKit provides it
+- **Hybrid apps** — WebViewer apps that combine modern web UI with FileMaker's platform-level capabilities (security, scripting, file system, printing)
+- **Staged progression** — WebViewer → web app with FileMaker backend → off FileMaker entirely, if and when that makes sense
+- **Meet developers where they are** — support existing editors rather than building a new one
+
+## Documents
+
+### [First Principles](first-principles.md)
+The foundational "why" behind every design decision. Covers: Agent First, Meet Developers Where They Are, Close the Loop for Agents, Start Where the On-Ramp Is Easiest (WebViewers), Full Web Apps Are Coming, and Deployed Code Should Behave Like FileMaker Code. This is the document to consult when making scope or priority decisions.
+
+### [Highlights](hilights.md)
+The "what" — concrete capabilities and the value pitch. Covers why WebViewers matter (UI freedom, performance gains), what ProofKit does well (metadata access, feedback loops, automated deployment, opinionated stack, flexibility), and the before/after comparison. This is the document to draw from for feature-focused content and demos.
+
+### [Hybrid Apps](hyrid-apps.md)
+Deep dive on what a hybrid FileMaker app actually is and why it's powerful. The "multi-user Electron" analogy. Covers inherited security, secure backend via scripts, CORS-free network access, file system access, printing/PDF generation, and plugin SDK extensibility. This is the document to draw from when explaining the hybrid app concept to developers who know web tech but not FileMaker, or vice versa.
+
+### [FAQ](faq-page.md)
+Anticipated questions and clear answers. Covers: what ProofKit is, what it produces, framework vs. tools, relationship to previous versions, open source status, token costs, relationship to ProofChat, agentic editing of scripts/tables, end-user requirements, and WebDirect support. This is the document to draw from for FAQ pages and support content.
+
+### [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md)
+Messaging strategy and positioning for the FileMaker community. Split into "things we say out loud" (you can code with agents in FileMaker, move in stages, security matters) and "things we imply" (Proof services for complex projects, Proof can help you leave FileMaker if that's the right outcome). This is the document to consult when writing marketing copy, conference talks, or community posts.
+
+## How to Use This Library
+
+1. **For landing pages**: Start with [Highlights](hilights.md) for the feature narrative, pull the "why" from [First Principles](first-principles.md), and use [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md) for tone and messaging guardrails.
+2. **For documentation pages**: Start with [Hybrid Apps](hyrid-apps.md) and [Highlights](hilights.md) for conceptual content, and [FAQ](faq-page.md) for anticipated questions.
+3. **For decision-making**: Consult [First Principles](first-principles.md) — it explains not just what we're building but what we're deliberately not building and why.

--- a/apps/docs/planning/v2/index.md
+++ b/apps/docs/planning/v2/index.md
@@ -31,8 +31,15 @@ Anticipated questions and clear answers. Covers: what ProofKit is, what it produ
 ### [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md)
 Messaging strategy and positioning for the FileMaker community. Split into "things we say out loud" (you can code with agents in FileMaker, move in stages, security matters) and "things we imply" (Proof services for complex projects, Proof can help you leave FileMaker if that's the right outcome). This is the document to consult when writing marketing copy, conference talks, or community posts.
 
+### [Content Required for Launch](content-required-for-launch.md)
+The launch content plan — what assets we need to produce and where they come from. Covers: a four-part getting started video series, a written getting started guide, a homepage redesign, an announcement blog post, a public FAQ page, and a technical requirements page. Each asset maps back to the source documents in this folder. This is the document to consult when planning production work and tracking what's done.
+
+### [Technical Requirements](technical-requirements.md)
+The hard requirements for ProofKit v2 at launch: FileMaker 22 or greater (with future releases tracking FileMaker 26), Claude Code and Claude Desktop as the tested AI environments, FileMaker Pro required for development, and the runtime environments where deployed apps will run (Pro, Go, WebDirect). Also calls out what is explicitly out of scope for this release — agentic editing of scripts, tables, and layouts. This is the document to consult when answering "will this work for me?" questions or writing the public technical requirements page.
+
 ## How to Use This Library
 
 1. **For landing pages**: Start with [Highlights](hilights.md) for the feature narrative, pull the "why" from [First Principles](first-principles.md), and use [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md) for tone and messaging guardrails.
 2. **For documentation pages**: Start with [Hybrid Apps](hyrid-apps.md) and [Highlights](hilights.md) for conceptual content, and [FAQ](faq-page.md) for anticipated questions.
 3. **For decision-making**: Consult [First Principles](first-principles.md) — it explains not just what we're building but what we're deliberately not building and why.
+4. **For launch planning**: Consult [Content Required for Launch](content-required-for-launch.md) for the full list of assets to produce, their source documents, and how they relate to each other.

--- a/apps/docs/planning/v2/index.md
+++ b/apps/docs/planning/v2/index.md
@@ -23,23 +23,34 @@ The foundational "why" behind every design decision. Covers: Agent First, Meet D
 The "what" — concrete capabilities and the value pitch. Covers why WebViewers matter (UI freedom, performance gains), what ProofKit does well (metadata access, feedback loops, automated deployment, opinionated stack, flexibility), and the before/after comparison. This is the document to draw from for feature-focused content and demos.
 
 ### [Hybrid Apps](hyrid-apps.md)
-Deep dive on what a hybrid FileMaker app actually is and why it's powerful. The "multi-user Electron" analogy. Covers inherited security, secure backend via scripts, CORS-free network access, file system access, printing/PDF generation, and plugin SDK extensibility. This is the document to draw from when explaining the hybrid app concept to developers who know web tech but not FileMaker, or vice versa.
+Deep dive on what a hybrid FileMaker app actually is and why it's powerful. The "multi-user Electron" analogy. Covers inherited security, secure backend via scripts, CORS-free network access, file system access, printing/PDF generation, offline support, and plugin SDK extensibility. This is the document to draw from when explaining the hybrid app concept to developers who know web tech but not FileMaker, or vice versa.
+
+### [Data Flow](data-flow.md)
+How data actually moves between FileMaker and a ProofKit WebViewer app at runtime. Includes a Mermaid diagram of the round-trip between the React app, FileMaker scripts, the database, and external systems. This is the document to draw from when developers ask "how does this actually work under the hood?" — pairs naturally with [Hybrid Apps](hyrid-apps.md).
+
+### [Alternatives](alternatives.md)
+How ProofKit compares to other ways of solving the same problem: hand-rolled WebViewers, pre-agentic FileMaker web frameworks, commercial tools, and leaving FileMaker entirely. Framed through the lens of agent-first design and closing the loop. This is the document to draw from when answering "why ProofKit and not X?" on the homepage, FAQ, or in sales conversations.
 
 ### [FAQ](faq-page.md)
-Anticipated questions and clear answers. Covers: what ProofKit is, what it produces, framework vs. tools, relationship to previous versions, open source status, token costs, relationship to ProofChat, agentic editing of scripts/tables, end-user requirements, and WebDirect support. This is the document to draw from for FAQ pages and support content.
+Anticipated questions and clear answers. Covers: what ProofKit is, what it produces, framework vs. tools, relationship to previous versions, open source status, pricing (free), token costs, agentic editing of scripts/tables, end-user requirements, WebDirect support, debugging and guardrails, migration between versions, team workflow, and where to get help. This is the document to draw from for FAQ pages and support content.
 
 ### [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md)
-Messaging strategy and positioning for the FileMaker community. Split into "things we say out loud" (you can code with agents in FileMaker, move in stages, security matters) and "things we imply" (Proof services for complex projects, Proof can help you leave FileMaker if that's the right outcome). This is the document to consult when writing marketing copy, conference talks, or community posts.
+Messaging strategy and positioning for the FileMaker community. The headline messages we want to land: you can code with agents in FileMaker, you can move in stages, and security comes built in. This is the document to consult when writing marketing copy, conference talks, or community posts.
 
 ### [Content Required for Launch](content-required-for-launch.md)
 The launch content plan — what assets we need to produce and where they come from. Covers: a four-part getting started video series, a written getting started guide, a homepage redesign, an announcement blog post, a public FAQ page, and a technical requirements page. Each asset maps back to the source documents in this folder. This is the document to consult when planning production work and tracking what's done.
 
 ### [Technical Requirements](technical-requirements.md)
-The hard requirements for ProofKit v2 at launch: FileMaker 22 or greater (with future releases tracking FileMaker 26), Claude Code and Claude Desktop as the tested AI environments, FileMaker Pro required for development, and the runtime environments where deployed apps will run (Pro, Go, WebDirect). Also calls out what is explicitly out of scope for this release — agentic editing of scripts, tables, and layouts. This is the document to consult when answering "will this work for me?" questions or writing the public technical requirements page.
+The hard requirements for ProofKit v2 at launch: FileMaker 22 or greater (with future releases tracking FileMaker 26), Claude Code and Claude Desktop as the tested AI environments, FileMaker Pro and Node.js (LTS) required for development, the runtime environments where deployed apps will run (Pro, Go, WebDirect), required developer background (web experience helpful but not required), and the ~30-minute time-to-first-deployed-app target. Also calls out what is explicitly out of scope for this release — agentic editing of scripts, tables, and layouts. This is the document to consult when answering "will this work for me?" questions or writing the public technical requirements page.
 
 ## How to Use This Library
 
 1. **For landing pages**: Start with [Highlights](hilights.md) for the feature narrative, pull the "why" from [First Principles](first-principles.md), and use [What We Want FM Devs to Hear](what-want-fm-devs-to-feel.md) for tone and messaging guardrails.
-2. **For documentation pages**: Start with [Hybrid Apps](hyrid-apps.md) and [Highlights](hilights.md) for conceptual content, and [FAQ](faq-page.md) for anticipated questions.
-3. **For decision-making**: Consult [First Principles](first-principles.md) — it explains not just what we're building but what we're deliberately not building and why.
-4. **For launch planning**: Consult [Content Required for Launch](content-required-for-launch.md) for the full list of assets to produce, their source documents, and how they relate to each other.
+2. **For documentation pages**: Start with [Hybrid Apps](hyrid-apps.md) and [Highlights](hilights.md) for conceptual content, [Data Flow](data-flow.md) for how the runtime fits together, and [FAQ](faq-page.md) for anticipated questions.
+3. **For competitive / "why ProofKit?" content**: Use [Alternatives](alternatives.md), grounded in [First Principles](first-principles.md).
+4. **For decision-making**: Consult [First Principles](first-principles.md) — it explains not just what we're building but what we're deliberately not building and why.
+5. **For launch planning**: Consult [Content Required for Launch](content-required-for-launch.md) for the full list of assets to produce, their source documents, and how they relate to each other.
+
+## Out of Scope for v2
+
+Items we'd like to ship eventually but have triaged out of the v2 launch live in [v2-next/](../v2-next/index.md). Currently parked there: [examples and case studies](../v2-next/examples-and-case-studies.md).

--- a/apps/docs/planning/v2/tech-stack.md
+++ b/apps/docs/planning/v2/tech-stack.md
@@ -1,0 +1,68 @@
+# Tech Stack
+
+This document inventories the pieces that make up a ProofKit-generated application — what gets installed, wired up, and operated for you when you set up a new project. It's a companion to [Highlights](hilights.md) (which explains *why* having an opinionated stack matters) and [Data Flow](data-flow.md) (which explains how those pieces talk to FileMaker at runtime).
+
+The shape of the stack follows directly from [First Principles](first-principles.md): each choice is one that AI coding agents already understand deeply, that closes the feedback loop, and that meets developers where they are.
+
+## The Core Framework
+
+### React + TypeScript
+
+The foundation of every ProofKit app. React is the most well-understood UI framework in LLM training data, which means agents write idiomatic React without prompting tricks. TypeScript adds the type information agents need to reason about your data and catch mistakes before they reach the browser.
+
+### shadcn/ui + Tailwind CSS
+
+The UI layer. shadcn/ui provides a library of accessible, beautifully designed components that get copied into your project (not installed as a black-box dependency), so the agent can read and modify them directly. Tailwind handles styling with utility classes — another pattern agents know cold. Dark and light mode work out of the box.
+
+### Vite
+
+The dev server and build tool. Fast hot-module reload during development, optimized bundles for deployment into the WebViewer.
+
+## Client Infrastructure
+
+### TanStack Query
+
+The data-fetching and caching layer. Query keeps your UI in sync with FileMaker server data without hammering the server and without manual refreshes. It deduplicates requests, caches intelligently, retries on failure, and gives the agent a predictable pattern for any data interaction. This is what makes a WebViewer app feel as snappy as a native UI even though every read goes through a FileMaker script.
+
+### TanStack Router
+
+The routing layer. A single bundle can host customers, invoices, dashboards, detail views, and more, with sidebar or top navigation. Type-safe routes mean the agent can't link to a page that doesn't exist.
+
+## The FileMaker Bridge
+
+### ProofKit FMDAPI + TypeGen
+
+Type-safe API clients generated from your FileMaker layouts. **TypeGen** reads your file's metadata and produces TypeScript types for every layout, field, and value list. **FMDAPI** uses those types to give the agent a fully typed client for the FileMaker Data API — so the agent knows the shape of every record it reads or writes. When the agent makes a typo or assumes a field that isn't there, TypeScript catches it at compile time, not at runtime in the WebViewer.
+
+### FMFetch
+
+A promise-based wrapper over the FileMaker WebViewer's script-callback primitives. WebViewers natively talk to FileMaker by calling a script and receiving a callback — a pattern that doesn't compose well with modern web code. FMFetch turns that into a `fetch`-shaped promise: the web code (and the agent writing it) can use the async/await idioms they already know, and FMFetch handles resolving the promise when the FileMaker script's callback fires.
+
+## The Agent Feedback Loop
+
+The framework pieces above are necessary but not sufficient. A ProofKit project also ships a deliberate set of guardrails that keep agents productive — see [Highlights — Closes the Loop](hilights.md#2-closes-the-loop-between-writing-testing-and-fixing) and [First Principles — Close the Loop for Agents](first-principles.md#3-close-the-loop-for-agents).
+
+- **Skills** — instructions and patterns the agent loads automatically, so it knows the conventions of a ProofKit project without being told each time.
+- **Deterministic tests** — the agent can run them and read the results, so a broken change surfaces immediately.
+- **Linters and formatters** — pre-configured so style and obvious bugs are caught before they reach review.
+- **Project setup** — a coherent baseline (folder structure, scripts, configs) so the agent never has to guess where something belongs.
+
+Together these turn the project into something the agent can drive autonomously: write code, run tests, read errors, fix, repeat — without a human shepherding each step.
+
+## Why These Choices
+
+Three properties drove every selection:
+
+1. **LLMs already know it.** React, TypeScript, Tailwind, TanStack — these are dense in training data. The agent writes them well on the first try.
+2. **It closes the loop.** Each piece either generates feedback the agent can read (types, test output, lint errors) or makes feedback faster (Vite's HMR, TanStack Query's predictable cache).
+3. **It composes.** Every piece was chosen knowing the others. You don't get a state-management library that fights the router or a UI kit that fights the styling system.
+
+If you've already invested in a different stack — Svelte, Vue, a different router — ProofKit can accommodate it. The opinionated path is the fastest route to a working app, but it's not the only path. See [Highlights — Stays Flexible](hilights.md#5-stays-flexible-when-you-need-it).
+
+## Related Documents
+
+- [Highlights](hilights.md) — value proposition and the case for an opinionated stack
+- [Data Flow](data-flow.md) — how these pieces talk to FileMaker at runtime
+- [Hybrid Apps](hyrid-apps.md) — what you get from running this stack inside a WebViewer
+- [Technical Requirements](technical-requirements.md) — the FileMaker, Node.js, and AI environment prerequisites for using the stack
+- [First Principles](first-principles.md) — the reasoning behind these choices

--- a/apps/docs/planning/v2/technical-requirements.md
+++ b/apps/docs/planning/v2/technical-requirements.md
@@ -1,0 +1,60 @@
+# Technical Requirements
+
+This document specifies the technical requirements for ProofKit v2 at launch — what versions of FileMaker are supported, which AI coding environments are tested and targeted, and what the deployed apps will run on. It also calls out what is explicitly *not* in scope for this release.
+
+## FileMaker Version
+
+**FileMaker 22 or greater** is required.
+
+Future releases of ProofKit will be tied to the next major version of FileMaker — **FileMaker 26**. As FileMaker evolves, we will track the platform's release cadence so that ProofKit can take advantage of new FileMaker capabilities (especially around how deployed code lives in the file — see [First Principles — Deployed Code Should Behave Like FileMaker Code](first-principles.md#6-deployed-code-should-behave-like-filemaker-code)).
+
+## AI Coding Environments
+
+ProofKit v2 is **fully tested with Claude Code and Claude Desktop**. These are our launch targets.
+
+In principle, ProofKit should also work with any agentic coding environment that supports MCP — Cursor, Codex, OpenCode, and others. Broad compatibility is an explicit goal, in line with [First Principles — Meet Developers Where They Are](first-principles.md#2-meet-developers-where-they-are--in-their-editor-of-choice). At launch, however, only Claude Code and Claude Desktop are formally supported and validated.
+
+We expect to expand official support to more environments as we test them.
+
+## Coding Environment (the Developer's Machine)
+
+To **build** ProofKit apps, a developer needs:
+
+- **FileMaker Pro** — required. The agentic coding workflow runs against an open FileMaker file in FileMaker Pro.
+- **FileMaker Server** — *not* required. ProofKit works against any open FileMaker file, whether it lives locally or is hosted on a server.
+
+In short: ProofKit needs an open file, not a particular hosting model.
+
+## Runtime Environments (Where Deployed Apps Run)
+
+Once an app is built and bundled into the FileMaker file, the resulting WebViewer app will run on:
+
+- **FileMaker Pro** (macOS and Windows)
+- **FileMaker Go** (iOS / iPadOS)
+- **FileMaker WebDirect**
+
+For WebDirect specifically, there are some additional considerations around window refresh behavior — see [FAQ — Does ProofKit work in WebDirect?](faq-page.md#does-proofkit-work-in-webdirect).
+
+## What's Out of Scope for This Release
+
+ProofKit v2 enables **agentic coding of WebViewer apps**. It does *not* enable agentic editing of other FileMaker elements:
+
+- Scripts
+- Tables and fields
+- Layouts
+- Value lists
+- Other schema or design elements
+
+These are on the roadmap. We are working with Claris on the underlying capabilities that would make some of these possible, and we may ship experimental features as those capabilities become available — see [FAQ — Can ProofKit enable agentic editing of scripts or tables?](faq-page.md#can-proofkit-enable-agentic-editing-of-scripts-or-tables). For now, the agent's writing scope is the WebViewer app itself.
+
+## Summary
+
+| Requirement | Value |
+|---|---|
+| FileMaker version | 22 or greater (next major version: 26) |
+| Tested AI environments | Claude Code, Claude Desktop |
+| Goal AI environments | Cursor, Codex, OpenCode, and other MCP-compatible agents |
+| Required for development | FileMaker Pro |
+| Required for hosting the file | None — local or server is fine |
+| Deployed app runtimes | FileMaker Pro (macOS/Windows), FileMaker Go, FileMaker WebDirect |
+| Agentic coding scope | WebViewer apps only (scripts, tables, layouts not yet supported) |

--- a/apps/docs/planning/v2/technical-requirements.md
+++ b/apps/docs/planning/v2/technical-requirements.md
@@ -22,8 +22,25 @@ To **build** ProofKit apps, a developer needs:
 
 - **FileMaker Pro** — required. The agentic coding workflow runs against an open FileMaker file in FileMaker Pro.
 - **FileMaker Server** — *not* required. ProofKit works against any open FileMaker file, whether it lives locally or is hosted on a server.
+- **Node.js (LTS)** — required. ProofKit's tooling runs on Node. Install the current LTS release from [nodejs.org](https://nodejs.org/).
 
-In short: ProofKit needs an open file, not a particular hosting model.
+In short: ProofKit needs an open file and Node installed locally — no particular hosting model required.
+
+## Developer Background
+
+You do **not** need to be a web developer to get started with ProofKit. The agent does the heavy lifting; the workflow is designed for FileMaker developers who may be writing their first React component.
+
+That said, prior knowledge accelerates everything:
+
+- **Familiarity with React and TypeScript** is helpful but not required. The agent can scaffold and modify components for you, and you'll learn as you go.
+- **Comfort with a terminal** is helpful — most agentic editors run from one.
+- **Git** is recommended for any non-trivial project, just as it would be for any web codebase.
+
+The getting started videos are designed so a developer with no prior web experience can follow along and get to a deployed app.
+
+## Time to First Deployed App
+
+The goal: **about 30 minutes from install to a working WebViewer app deployed in your FileMaker file**, following the [getting started video series](content-required-for-launch.md#getting-started-video-series). The videos walk through the path end to end so anyone can verify the timing by watching.
 
 ## Runtime Environments (Where Deployed Apps Run)
 
@@ -54,7 +71,9 @@ These are on the roadmap. We are working with Claris on the underlying capabilit
 | FileMaker version | 22 or greater (next major version: 26) |
 | Tested AI environments | Claude Code, Claude Desktop |
 | Goal AI environments | Cursor, Codex, OpenCode, and other MCP-compatible agents |
-| Required for development | FileMaker Pro |
+| Required for development | FileMaker Pro, Node.js (LTS) |
 | Required for hosting the file | None — local or server is fine |
+| Web development experience | Helpful but not required |
+| Time to first deployed app | ~30 minutes (per the getting started videos) |
 | Deployed app runtimes | FileMaker Pro (macOS/Windows), FileMaker Go, FileMaker WebDirect |
 | Agentic coding scope | WebViewer apps only (scripts, tables, layouts not yet supported) |

--- a/apps/docs/planning/v2/what-want-fm-devs-to-feel.md
+++ b/apps/docs/planning/v2/what-want-fm-devs-to-feel.md
@@ -11,20 +11,6 @@ The headline message: you can code with agents in FileMaker. Several reasons thi
 - Move in stages. Start by replacing layouts (low risk, FileMaker security inherited). Then progress to web apps when you're ready. Then maybe off FileMaker entirely if it makes sense. People trying to leap straight from FileMaker to a custom AI-built stack are running into walls — databases getting deleted, codebases collapsing 4-6 months in. This staged approach is a core principle — see [First Principles — Start Where the On-Ramp Is Easiest](first-principles.md#4-start-where-the-on-ramp-is-easiest-webviewers) and [First Principles — Full Web Apps Are Coming, Too](first-principles.md#5-full-web-apps-are-coming-too).
 - Many customers may never need to leave. If FileMaker Server is a tiny percentage of cost structure and the scale works, there's no reason to migrate. ProofKit extends the runway.
 
-## Things we want to imply 
-
-These are messages we want to convey, but this should be more SHOW!, DON'T Tell. We want to leave people feeling like if they need to talk to the leader in this space they should talk to us. 
-
-## You might still need Proof services.
-
-For some people, it may make sense for them to hire Proof as the consultant or primary implementer. for these types of projects, especially as they get very complex or they move into replacing the file maker UI entirely with a custom-built web app that connects to a FileMaker back end. Because while ProofKit makes this as easy as possible, it is still really helpful to have a good strong understanding of how to do these things at scale. So we are the experts in this. We've been doing this longer than anybody, and we are available to help. Under the right project configuration.
-
-## You might want to leave FileMaker completely
-
-Yes, you might. For some companies, the economics simply may not work anymore. FileMaker may no longer make sense from a cost perspective, or you may be running into scale or performance limits that cannot be solved by moving the UI into a web viewer or even a separate web app.
-
-If leaving FileMaker is the right outcome, Proof has a strong process for using AI to complete that migration. We still believe there is value in moving step by step: first converting some UI to web viewers, then possibly moving to a web app, and only then deciding whether to leave FileMaker altogether. Wherever that path leads, Proof can be your partner in getting there.
-
 ---
 
 For how these messages translate into specific launch assets — the homepage redesign, announcement blog post, and getting started videos — see [Content Required for Launch](content-required-for-launch.md).

--- a/apps/docs/planning/v2/what-want-fm-devs-to-feel.md
+++ b/apps/docs/planning/v2/what-want-fm-devs-to-feel.md
@@ -24,3 +24,7 @@ For some people, it may make sense for them to hire Proof as the consultant or p
 Yes, you might. For some companies, the economics simply may not work anymore. FileMaker may no longer make sense from a cost perspective, or you may be running into scale or performance limits that cannot be solved by moving the UI into a web viewer or even a separate web app.
 
 If leaving FileMaker is the right outcome, Proof has a strong process for using AI to complete that migration. We still believe there is value in moving step by step: first converting some UI to web viewers, then possibly moving to a web app, and only then deciding whether to leave FileMaker altogether. Wherever that path leads, Proof can be your partner in getting there.
+
+---
+
+For how these messages translate into specific launch assets — the homepage redesign, announcement blog post, and getting started videos — see [Content Required for Launch](content-required-for-launch.md).

--- a/apps/docs/planning/v2/what-want-fm-devs-to-feel.md
+++ b/apps/docs/planning/v2/what-want-fm-devs-to-feel.md
@@ -1,0 +1,26 @@
+
+# What do we want the FileMaker world to hear when we go public?
+
+## Things we can say out loud. 
+
+## You can code with agents in FileMaker
+The headline message: you can code with agents in FileMaker. Several reasons this matters:
+
+- You don't have to leave FileMaker just to vibe code. A large percentage of customers and developers are moving off the platform because they think they can't. They can. See [Highlights](hilights.md) for what ProofKit concretely enables.
+- Security is becoming a serious deal. If you yank your stuff out of FileMaker and onto something you don't understand, you can expose yourself to significant security risks. Staying inherits the FileMaker security you already know — see [Hybrid Apps — Inherited Security](hyrid-apps.md#inherited-security).
+- Move in stages. Start by replacing layouts (low risk, FileMaker security inherited). Then progress to web apps when you're ready. Then maybe off FileMaker entirely if it makes sense. People trying to leap straight from FileMaker to a custom AI-built stack are running into walls — databases getting deleted, codebases collapsing 4-6 months in. This staged approach is a core principle — see [First Principles — Start Where the On-Ramp Is Easiest](first-principles.md#4-start-where-the-on-ramp-is-easiest-webviewers) and [First Principles — Full Web Apps Are Coming, Too](first-principles.md#5-full-web-apps-are-coming-too).
+- Many customers may never need to leave. If FileMaker Server is a tiny percentage of cost structure and the scale works, there's no reason to migrate. ProofKit extends the runway.
+
+## Things we want to imply 
+
+These are messages we want to convey, but this should be more SHOW!, DON'T Tell. We want to leave people feeling like if they need to talk to the leader in this space they should talk to us. 
+
+## You might still need Proof services.
+
+For some people, it may make sense for them to hire Proof as the consultant or primary implementer. for these types of projects, especially as they get very complex or they move into replacing the file maker UI entirely with a custom-built web app that connects to a FileMaker back end. Because while ProofKit makes this as easy as possible, it is still really helpful to have a good strong understanding of how to do these things at scale. So we are the experts in this. We've been doing this longer than anybody, and we are available to help. Under the right project configuration.
+
+## You might want to leave FileMaker completely
+
+Yes, you might. For some companies, the economics simply may not work anymore. FileMaker may no longer make sense from a cost perspective, or you may be running into scale or performance limits that cannot be solved by moving the UI into a web viewer or even a separate web app.
+
+If leaving FileMaker is the right outcome, Proof has a strong process for using AI to complete that migration. We still believe there is value in moving step by step: first converting some UI to web viewers, then possibly moving to a web app, and only then deciding whether to leave FileMaker altogether. Wherever that path leads, Proof can be your partner in getting there.


### PR DESCRIPTION
## Summary
- Add an internal ProofKit v2 planning content library under `apps/docs/planning/v2`.
- Include first principles, highlights, hybrid app positioning, FAQ, messaging guardrails, and an index linking the documents.

## Test plan
- `pnpm run ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive ProofKit v2 internal planning library and index.
  * New FAQ covering capabilities, deployment, runtime expectations, and cost framing.
  * New first-principles, highlights, alternatives, and tech-stack pages defining scope, principles, and stack choices.
  * New guides on hybrid WebViewer apps, data flow, technical requirements, launch content, messaging, and launch asset needs.
  * Added a deferred “v2-next” section with examples and case-study plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->