### PR TITLE
Make init git commit failures non-blocking

### DIFF
--- a/.changeset/cool-dryers-care.md
+++ b/.changeset/cool-dryers-care.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/cli": patch
+---
+
+Make initial git commit failures non-blocking during CLI init.

--- a/packages/cli/src/services/live.ts
+++ b/packages/cli/src/services/live.ts
@@ -235,6 +235,12 @@ const gitService = {
       yield* withCommandError("git", ["add", "."], projectDir, () => execa("git", ["add", "."], { cwd: projectDir }));
       yield* withCommandError("git", ["commit", "-m", "Initial commit"], projectDir, () =>
         execa("git", ["commit", "-m", "Initial commit"], { cwd: projectDir }),
+      ).pipe(
+        Effect.catchTag("ExternalCommandError", () =>
+          Effect.sync(() => {
+            consoleService.warn("Git initial commit failed; continuing without commit.");
+          }),
+        ),
       );
     }),
 };

--- a/packages/cli/tests/live-git-init.test.ts
+++ b/packages/cli/tests/live-git-init.test.ts
@@ -1,0 +1,95 @@
+import os from "node:os";
+import path from "node:path";
+import { Effect } from "effect";
+import fs from "fs-extra";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeInitPlan } from "~/core/executeInitPlan.js";
+import { planInit } from "~/core/planInit.js";
+import { makeLiveLayer } from "~/services/live.js";
+import { getSharedTemplateDir, makeInitRequest } from "./init-fixtures.js";
+
+const { execaMock, warnMock, successMock } = vi.hoisted(() => ({
+  execaMock: vi.fn(),
+  warnMock: vi.fn(),
+  successMock: vi.fn(),
+}));
+
+vi.mock("execa", () => ({
+  execa: execaMock,
+}));
+
+vi.mock("~/utils/prompts.js", () => ({
+  confirmPrompt: vi.fn(),
+  spinner: vi.fn(),
+  isCancel: vi.fn(() => false),
+  log: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: successMock,
+    warn: warnMock,
+  },
+  multiSearchSelectPrompt: vi.fn(),
+  note: vi.fn(),
+  passwordPrompt: vi.fn(),
+  searchSelectPrompt: vi.fn(),
+  selectPrompt: vi.fn(),
+  textPrompt: vi.fn(),
+}));
+
+describe("live git init", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    execaMock.mockImplementation((command: string, args: string[]) => {
+      if (command === "pnpm" && args[0] === "-v") {
+        return Promise.resolve({ stdout: "10.27.0" });
+      }
+
+      if (command === "git" && args[0] === "commit") {
+        throw new Error("Author identity unknown");
+      }
+
+      return Promise.resolve({ stdout: "", stderr: "" });
+    });
+  });
+
+  it("warns and continues when initial git commit fails", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "proofkit-live-git-"));
+    const plan = planInit(
+      makeInitRequest({
+        projectName: "git-warn-app",
+        scopedAppName: "git-warn-app",
+        appDir: "git-warn-app",
+        appType: "browser",
+        ui: "shadcn",
+        dataSource: "none",
+        packageManager: "pnpm",
+        noInstall: true,
+        noGit: false,
+        force: false,
+        cwd,
+        importAlias: "~/",
+        nonInteractive: true,
+        debug: false,
+        skipFileMakerSetup: false,
+        hasExplicitFileMakerInputs: false,
+      }),
+      {
+        templateDir: getSharedTemplateDir("nextjs-shadcn"),
+      },
+    );
+
+    await expect(
+      Effect.runPromise(executeInitPlan(plan).pipe(makeLiveLayer({ cwd, debug: false, nonInteractive: true }))),
+    ).resolves.toBeDefined();
+
+    expect(execaMock).toHaveBeenCalledWith("git", ["init"], expect.objectContaining({ cwd: plan.targetDir }));
+    expect(execaMock).toHaveBeenCalledWith("git", ["add", "."], expect.objectContaining({ cwd: plan.targetDir }));
+    expect(execaMock).toHaveBeenCalledWith(
+      "git",
+      ["commit", "-m", "Initial commit"],
+      expect.objectContaining({ cwd: plan.targetDir }),
+    );
+    expect(warnMock).toHaveBeenCalledWith("Git initial commit failed; continuing without commit.");
+    expect(successMock).toHaveBeenCalledWith(expect.stringContaining("Created git-warn-app"));
+  });
+});


### PR DESCRIPTION
## Summary
- Ignore initial `git commit` failures during CLI init.
- Show a warning and continue project creation when commit setup fails.
- Add coverage for the non-blocking git init path.

## Testing
- `pnpm run ci`
- Added Vitest case for failed initial `git commit`
- Verified init still completes and warns instead of aborting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * CLI initialization now handles git commit failures gracefully. When the initial commit fails during app setup, a warning is logged and the initialization process continues instead of terminating. This ensures users can proceed with project creation even if git configuration issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->