### PR TITLE
feat(docs): add Open Graph images

### DIFF
--- a/apps/docs/src/app/(home)/examples/page.tsx
+++ b/apps/docs/src/app/(home)/examples/page.tsx
@@ -2,6 +2,9 @@ import { DownloadButton } from "@/components/DownloadButton";
 import { ExamplesGallery } from "@/components/examples/ExamplesGallery";
 import { MarketingNav } from "@/components/MarketingNav";
 import { ShadcnPresetThemes } from "@/components/ShadcnPresetThemes";
+import { getMarketingMetadata } from "@/lib/og";
+
+export const metadata = getMarketingMetadata("examples");
 
 const examples: {
   desc: string;

--- a/apps/docs/src/app/(home)/how-it-works/page.tsx
+++ b/apps/docs/src/app/(home)/how-it-works/page.tsx
@@ -2,6 +2,9 @@ import { ArrowRight, Code, Download, Eye, RefreshCw, Server, Zap } from "lucide-
 import Link from "next/link";
 import { MarketingNav } from "@/components/MarketingNav";
 import { MarketingCard, MarketingSection } from "@/components/marketing-section";
+import { getMarketingMetadata } from "@/lib/og";
+
+export const metadata = getMarketingMetadata("how-it-works");
 
 export default function HowItWorksPage() {
   return (

--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -10,6 +10,9 @@ import { ProofLogo } from "@/components/ProofLogo";
 import { ClaudeAiIcon } from "@/components/ui/svgs/claudeAiIcon";
 import { CodexDark } from "@/components/ui/svgs/codexDark";
 import { CursorDark } from "@/components/ui/svgs/cursorDark";
+import { getMarketingMetadata } from "@/lib/og";
+
+export const metadata = getMarketingMetadata("home");
 
 const stackItems = [
   { name: "Cursor", icon: <CursorDark className="size-5" fill="currentColor" /> },

--- a/apps/docs/src/app/(home)/why-proofkit/page.tsx
+++ b/apps/docs/src/app/(home)/why-proofkit/page.tsx
@@ -1,6 +1,9 @@
 import { DownloadButton } from "@/components/DownloadButton";
 import { MarketingNav } from "@/components/MarketingNav";
 import { MarketingCard, MarketingSection } from "@/components/marketing-section";
+import { getMarketingMetadata } from "@/lib/og";
+
+export const metadata = getMarketingMetadata("why-proofkit");
 
 export default function WhyProofkitPage() {
   return (

--- a/apps/docs/src/app/(home)/why-webviewers/page.tsx
+++ b/apps/docs/src/app/(home)/why-webviewers/page.tsx
@@ -3,6 +3,9 @@ import Link from "next/link";
 import DataFlowDiagram from "@/components/DataFlowDiagramLazy";
 import { MarketingNav } from "@/components/MarketingNav";
 import { MarketingCard, MarketingSection } from "@/components/marketing-section";
+import { getMarketingMetadata } from "@/lib/og";
+
+export const metadata = getMarketingMetadata("why-webviewers");
 
 export default function WhyWebviewersPage() {
   return (

--- a/apps/docs/src/app/docs/(docs)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/(docs)/[[...slug]]/page.tsx
@@ -1,8 +1,10 @@
 import { createRelativeLink } from "fumadocs-ui/mdx";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { LLMCopyButton, ViewOptions } from "@/components/ai/page-actions";
-import { source } from "@/lib/source";
+import { siteName } from "@/lib/og";
+import { getPageImage, source } from "@/lib/source";
 import { getMDXComponents } from "@/mdx-components";
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
@@ -50,7 +52,7 @@ export async function generateStaticParams() {
   return source.generateParams();
 }
 
-export async function generateMetadata(props: { params: Promise<{ slug?: string[] }> }) {
+export async function generateMetadata(props: { params: Promise<{ slug?: string[] }> }): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) {
@@ -58,15 +60,34 @@ export async function generateMetadata(props: { params: Promise<{ slug?: string[
   }
 
   const url = `https://proofkit.proof.sh${page.url}`;
+  const image = getPageImage(page).url;
 
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: page.url,
+    },
     openGraph: {
       title: page.data.title,
       description: page.data.description ?? undefined,
       type: "article",
       url,
+      siteName,
+      images: [
+        {
+          url: image,
+          width: 1200,
+          height: 630,
+          alt: `${page.data.title} - ${siteName}`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: page.data.title,
+      description: page.data.description ?? undefined,
+      images: [image],
     },
   };
 }

--- a/apps/docs/src/app/og/docs/[...slug]/route.tsx
+++ b/apps/docs/src/app/og/docs/[...slug]/route.tsx
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+import { createOgImageResponse } from "@/lib/og";
+import { getPageImage, source } from "@/lib/source";
+
+export const revalidate = false;
+
+export async function GET(_request: Request, { params }: { params: Promise<{ slug: string[] }> }) {
+  const { slug } = await params;
+  const page = source.getPage(slug.slice(0, -1));
+
+  if (!page) {
+    notFound();
+  }
+
+  return createOgImageResponse({
+    title: page.data.title,
+    description: page.data.description,
+    eyebrow: "ProofKit Docs",
+  });
+}
+
+export function generateStaticParams() {
+  return source.getPages().map((page) => ({
+    slug: getPageImage(page).segments,
+  }));
+}

--- a/apps/docs/src/app/og/marketing/[slug]/route.tsx
+++ b/apps/docs/src/app/og/marketing/[slug]/route.tsx
@@ -1,0 +1,28 @@
+import { notFound } from "next/navigation";
+import { createOgImageResponse, marketingPages } from "@/lib/og";
+
+export const revalidate = false;
+
+const PNG_EXTENSION = /\.png$/;
+
+export async function GET(_request: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const pageKey = slug.replace(PNG_EXTENSION, "") as keyof typeof marketingPages;
+  const page = marketingPages[pageKey];
+
+  if (!page) {
+    notFound();
+  }
+
+  return createOgImageResponse({
+    title: page.title,
+    description: page.description,
+    eyebrow: page.eyebrow,
+  });
+}
+
+export function generateStaticParams() {
+  return Object.keys(marketingPages).map((slug) => ({
+    slug: `${slug}.png`,
+  }));
+}

--- a/apps/docs/src/lib/og.tsx
+++ b/apps/docs/src/lib/og.tsx
@@ -1,0 +1,243 @@
+import type { Metadata } from "next";
+import { ImageResponse } from "next/og";
+
+export const siteName = "ProofKit";
+export const siteUrl = "https://proofkit.proof.sh";
+export const defaultDescription =
+  "Create modern web interfaces for FileMaker with AI agents, useful context, and a closed build/test/deploy loop.";
+
+export const marketingPages = {
+  home: {
+    title: "Build like anything is possible again.",
+    description: defaultDescription,
+    path: "/",
+    eyebrow: "ProofKit",
+  },
+  examples: {
+    title: "What You Can Build",
+    description: "Examples of modern web UI you can build for FileMaker with agentic coding and a modern web stack.",
+    path: "/examples",
+    eyebrow: "Examples",
+  },
+  "how-it-works": {
+    title: "How ProofKit Works",
+    description: "Agent-first architecture, from FileMaker schema to deployed Web Viewer app in a single session.",
+    path: "/how-it-works",
+    eyebrow: "How it works",
+  },
+  "why-webviewers": {
+    title: "The Hybrid App Advantage",
+    description:
+      "Web UI in a FileMaker shell, with FileMaker still providing data, security, scripting, and infrastructure.",
+    path: "/why-webviewers",
+    eyebrow: "Why WebViewers",
+  },
+  "why-proofkit": {
+    title: "Why ProofKit",
+    description: "ProofKit is built for agents writing code with humans supervising.",
+    path: "/why-proofkit",
+    eyebrow: "Why ProofKit",
+  },
+} as const;
+
+export type MarketingPageKey = keyof typeof marketingPages;
+
+interface OgImageOptions {
+  title: string;
+  description?: string | null;
+  eyebrow?: string;
+}
+
+export function getMarketingPageImage(page: MarketingPageKey) {
+  return {
+    url: `/og/marketing/${page}.png`,
+    width: 1200,
+    height: 630,
+    alt: `${marketingPages[page].title} - ${siteName}`,
+  };
+}
+
+export function getMarketingMetadata(page: MarketingPageKey): Metadata {
+  const data = marketingPages[page];
+  const image = getMarketingPageImage(page);
+
+  return {
+    title: data.title,
+    description: data.description,
+    alternates: {
+      canonical: data.path,
+    },
+    openGraph: {
+      title: data.title,
+      description: data.description,
+      type: "website",
+      url: data.path,
+      siteName,
+      images: [image],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: data.title,
+      description: data.description,
+      images: [image.url],
+    },
+  };
+}
+
+export function createOgImageResponse({ title, description, eyebrow = siteName }: OgImageOptions) {
+  let titleSize = 74;
+  if (title.length > 58) {
+    titleSize = 54;
+  } else if (title.length > 36) {
+    titleSize = 62;
+  }
+
+  return new ImageResponse(
+    <div
+      style={{
+        alignItems: "stretch",
+        backgroundColor: "#020103",
+        backgroundImage:
+          "radial-gradient(circle at 22% -8%, rgba(209,90,187,0.78), transparent 35%), radial-gradient(circle at 82% 4%, rgba(137,35,107,0.7), transparent 32%), linear-gradient(180deg, #120611 0%, #020103 66%, #000000 100%)",
+        color: "white",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "Inter, Arial, sans-serif",
+        height: "100%",
+        justifyContent: "space-between",
+        overflow: "hidden",
+        padding: "58px 70px",
+        position: "relative",
+        width: "100%",
+      }}
+    >
+      <div
+        style={{
+          background: "rgba(255,255,255,0.07)",
+          border: "1px solid rgba(255,255,255,0.12)",
+          borderRadius: 24,
+          display: "flex",
+          height: 74,
+          left: 62,
+          position: "absolute",
+          right: 62,
+          top: 42,
+        }}
+      />
+
+      <div style={{ alignItems: "center", display: "flex", justifyContent: "space-between", zIndex: 1 }}>
+        <div style={{ alignItems: "center", display: "flex", fontSize: 28, fontWeight: 800, letterSpacing: -1 }}>
+          <span style={{ color: "#ff595e", marginRight: 8 }}>{">_"}</span>
+          <span style={{ color: "#d15abb" }}>proofkit</span>
+        </div>
+        <div style={{ color: "rgba(255,255,255,0.48)", fontSize: 21, fontWeight: 700 }}>{siteName}</div>
+      </div>
+
+      <div style={{ display: "flex", gap: 42, zIndex: 1 }}>
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: 760 }}>
+          <div
+            style={{
+              alignItems: "center",
+              alignSelf: "flex-start",
+              background: "rgba(255,255,255,0.08)",
+              border: "1px solid rgba(255,255,255,0.13)",
+              borderRadius: 999,
+              color: "rgba(255,255,255,0.66)",
+              display: "flex",
+              fontSize: 20,
+              fontWeight: 700,
+              marginBottom: 26,
+              padding: "9px 18px",
+            }}
+          >
+            <span
+              style={{
+                background: "#ffffff",
+                borderRadius: 999,
+                color: "#050505",
+                fontSize: 15,
+                fontWeight: 900,
+                marginRight: 12,
+                padding: "5px 10px",
+              }}
+            >
+              NEW
+            </span>
+            {eyebrow}
+          </div>
+
+          <div style={{ fontSize: titleSize, fontWeight: 900, letterSpacing: -3, lineHeight: 0.93 }}>{title}</div>
+
+          {description ? (
+            <div
+              style={{
+                color: "rgba(255,255,255,0.62)",
+                fontSize: 28,
+                fontWeight: 600,
+                lineHeight: 1.35,
+                marginTop: 28,
+                maxWidth: 720,
+              }}
+            >
+              {description}
+            </div>
+          ) : null}
+        </div>
+
+        <div
+          style={{
+            alignSelf: "flex-end",
+            background: "rgba(255,255,255,0.07)",
+            border: "1px solid rgba(255,255,255,0.12)",
+            borderRadius: 32,
+            display: "flex",
+            flexDirection: "column",
+            gap: 14,
+            minWidth: 290,
+            padding: 22,
+          }}
+        >
+          {["AI Agent", "MCP Server", "FileMaker", "Web Viewer"].map((label, index) => (
+            <div
+              key={label}
+              style={{
+                alignItems: "center",
+                background: index === 2 ? "rgba(209,90,187,0.22)" : "rgba(255,255,255,0.06)",
+                border: "1px solid rgba(255,255,255,0.11)",
+                borderRadius: 18,
+                color: index === 2 ? "#ffffff" : "rgba(255,255,255,0.7)",
+                display: "flex",
+                fontSize: 22,
+                fontWeight: 800,
+                justifyContent: "space-between",
+                padding: "15px 18px",
+              }}
+            >
+              {label}
+              <span style={{ color: "rgba(255,255,255,0.34)" }}>{index < 3 ? ">" : ""}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div
+        style={{
+          color: "rgba(255,255,255,0.34)",
+          display: "flex",
+          fontSize: 19,
+          fontWeight: 800,
+          justifyContent: "center",
+          letterSpacing: 6,
+          textTransform: "uppercase",
+          zIndex: 1,
+        }}
+      >
+        Built for the modern FileMaker stack
+      </div>
+    </div>,
+    {
+      height: 630,
+      width: 1200,
+    },
+  );
+}

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -49,3 +49,14 @@ export const source = loader({
   },
   source: docs.toFumadocsSource(),
 });
+
+type SourcePage = ReturnType<typeof source.getPages>[number];
+
+export function getPageImage(page: SourcePage) {
+  const segments = [...page.slugs, "image.png"];
+
+  return {
+    segments,
+    url: `/og/docs/${segments.join("/")}`,
+  };
+}


### PR DESCRIPTION
## Summary
- Add dynamic Open Graph image routes for docs and marketing pages.
- Wire docs and marketing page metadata to use the generated social images.

## Test plan
- pnpm run ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented dynamic Open Graph image generation for documentation and marketing pages with optimized social media sharing previews
  * Enhanced metadata across documentation pages to improve SEO and social media discoverability
  * Added dedicated image endpoints for docs and marketing pages to enable rich preview cards when shared online

<!-- end of auto-generated comment: release notes by coderabbit.ai -->