### PR TITLE
docs: clarify Connect to MCP setup

### DIFF
--- a/apps/docs/content/docs/ai/getting-started.mdx
+++ b/apps/docs/content/docs/ai/getting-started.mdx
@@ -6,7 +6,7 @@ description: Follow the ProofKit AI path from install to deployed Web Viewer app
 import { Callout } from "fumadocs-ui/components/callout";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 
-This guide is the happy path for ProofKit v2. It mirrors the planned video series: install ProofKit, connect your FileMaker file, verify the agent connection, explore your file, build a Web Viewer app, and deploy it back into FileMaker.
+This guide is the happy path for ProofKit v2. It mirrors the planned video series: install ProofKit, connect and verify your FileMaker file, explore your file, build a Web Viewer app, and deploy it back into FileMaker.
 
 <Callout title="TODO: Video - Full getting started walkthrough">
   Embed the complete install-to-deploy walkthrough here, or link to the individual videos once they are published.
@@ -32,7 +32,7 @@ See [Technical Requirements](/docs/ai/technical-requirements) for the full suppo
 
     Continue with [Install and Connect](/docs/ai/install-and-connect).
 
-    <Callout title="TODO: Video - Install and connect ProofKit">
+    <Callout title="TODO: Video - Install ProofKit add-on">
       Show downloading ProofKit and installing the add-on.
     </Callout>
   </Step>

--- a/apps/docs/content/docs/ai/getting-started.mdx
+++ b/apps/docs/content/docs/ai/getting-started.mdx
@@ -16,7 +16,7 @@ This guide is the happy path for ProofKit v2. It mirrors the planned video serie
 
 You need FileMaker Pro, a supported Node.js LTS release, and an MCP-compatible coding agent such as Cursor, Claude Code, Codex, OpenCode, or another agent that can use MCP servers.
 
-For Node.js, choose a release that is explicitly marked LTS. Today that means **Node.js 22**, **Node.js 24**, or **Node.js 26**. If you are setting up Node for the first time, start with the [official Node.js download page](https://nodejs.org/en/download/).
+For Node.js, choose a release that is explicitly marked LTS. If you are setting up Node for the first time, start with the [official Node.js download page](https://nodejs.org/en/download/).
 
 If you are using a chat-first tool such as Claude Desktop or ChatGPT, you can still use ProofKit to explore FileMaker metadata and data. Building Web Viewer apps requires a coding agent that can work in a project folder. See [Chat Mode vs Code Mode](/docs/ai/chat-vs-code-mode) for the difference.
 

--- a/apps/docs/content/docs/ai/getting-started.mdx
+++ b/apps/docs/content/docs/ai/getting-started.mdx
@@ -28,12 +28,12 @@ See [Technical Requirements](/docs/ai/technical-requirements) for the full suppo
   <Step>
     **Install ProofKit and add it to your FileMaker file.**
 
-    Run the installer, add the ProofKit add-on to your file, and enable the plug-in if FileMaker asks.
+    Run the installer and add the ProofKit add-on to your file.
 
     Continue with [Install and Connect](/docs/ai/install-and-connect).
 
     <Callout title="TODO: Video - Install and connect ProofKit">
-      Show downloading ProofKit, installing the add-on, and enabling the plug-in.
+      Show downloading ProofKit and installing the add-on.
     </Callout>
   </Step>
 

--- a/apps/docs/content/docs/ai/getting-started.mdx
+++ b/apps/docs/content/docs/ai/getting-started.mdx
@@ -6,10 +6,10 @@ description: Follow the ProofKit AI path from install to deployed Web Viewer app
 import { Callout } from "fumadocs-ui/components/callout";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 
-This guide is the happy path for ProofKit v2. It mirrors the planned video series: install and connect, explore your FileMaker file, build a Web Viewer app, and deploy it back into FileMaker.
+This guide is the happy path for ProofKit v2. It mirrors the planned video series: install ProofKit, connect your FileMaker file, verify the agent connection, explore your file, build a Web Viewer app, and deploy it back into FileMaker.
 
 <Callout title="TODO: Video - Full getting started walkthrough">
-  Embed the complete install-to-deploy walkthrough here, or link to the four individual videos once they are published.
+  Embed the complete install-to-deploy walkthrough here, or link to the individual videos once they are published.
 </Callout>
 
 ## Before you start
@@ -22,18 +22,30 @@ If you are using a chat-first tool such as Claude Desktop or ChatGPT, you can st
 
 See [Technical Requirements](/docs/ai/technical-requirements) for the full support matrix.
 
-## The four-step path
+## The five-step path
 
 <Steps>
   <Step>
-    **Install ProofKit and connect to your FileMaker file.**
+    **Install ProofKit and add it to your FileMaker file.**
 
-    Run the installer, add the ProofKit add-on to your file, enable the plug-in if needed, and confirm your agent can see the open file.
+    Run the installer, add the ProofKit add-on to your file, and enable the plug-in if FileMaker asks.
 
     Continue with [Install and Connect](/docs/ai/install-and-connect).
 
     <Callout title="TODO: Video - Install and connect ProofKit">
-      Show downloading ProofKit, installing the add-on, enabling the plug-in, and confirming the agent can see the file.
+      Show downloading ProofKit, installing the add-on, and enabling the plug-in.
+    </Callout>
+  </Step>
+
+  <Step>
+    **Connect your FileMaker file to MCP and verify it.**
+
+    Run the **Connect to MCP** script in FileMaker Pro, keep the connector Web Viewer open in Browse mode, and ask your agent to confirm it can see the open file.
+
+    Continue with [Install and Connect](/docs/ai/install-and-connect#verify-the-connection).
+
+    <Callout title="TODO: Video - Connect and verify the FileMaker file">
+      Show running the Connect to MCP script, leaving the connector open, and confirming the agent can see the file.
     </Callout>
   </Step>
 

--- a/apps/docs/content/docs/ai/install-and-connect.mdx
+++ b/apps/docs/content/docs/ai/install-and-connect.mdx
@@ -62,7 +62,7 @@ If nothing is connected, tell me what to fix before I continue.
 
 _Claude Code following the prompt and confirming the connected file and layouts._
 
-If the agent cannot see your file, confirm the **Connect to MCP** script is running and the connector Web Viewer is still open in Browse mode. For the full checklist, see [fmBridge troubleshooting](/docs/webviewer/fm-bridge#troubleshooting).
+If the agent cannot see your file, re-run **Connect to MCP** in FileMaker Pro and confirm the connector Web Viewer remains open in Browse mode. For the full checklist, see [fmBridge troubleshooting](/docs/webviewer/fm-bridge#troubleshooting).
 
 ## Next step
 

--- a/apps/docs/content/docs/ai/install-and-connect.mdx
+++ b/apps/docs/content/docs/ai/install-and-connect.mdx
@@ -8,7 +8,7 @@ import { Step, Steps } from "fumadocs-ui/components/steps";
 
 The first milestone is simple: your coding agent should be able to communicate with an open FileMaker file through ProofKit.
 
-ProofKit installs several pieces that work together: a FileMaker add-on, a FileMaker plug-in, an MCP server, and agent integrations.
+ProofKit installs several pieces that work together: a FileMaker add-on, a FileMaker plug-in, a connector script, an MCP server, and agent integrations.
 
 <Callout title="TODO: Screenshot - ProofKit installer">
   Capture the installer screen for macOS, including any step where the agent integrations are selected or confirmed.
@@ -36,9 +36,15 @@ ProofKit installs several pieces that work together: a FileMaker add-on, a FileM
   </Step>
 
   <Step>
-    **Enable the plug-in if FileMaker asks.**
+    **Run the Connect to MCP script.**
 
-    The plug-in provides the local API used by the MCP server and the Web Viewer proxy used for verification.
+    In FileMaker Pro, run the **Connect to MCP** script installed by the add-on. It opens the connector Web Viewer that registers your file with the local MCP server.
+  </Step>
+
+  <Step>
+    **Keep the connector open and enable the plug-in if asked.**
+
+    Leave the connector Web Viewer open in Browse mode while you work. The plug-in provides the local API used by the MCP server and the Web Viewer proxy used for verification.
   </Step>
 </Steps>
 
@@ -56,7 +62,7 @@ If nothing is connected, tell me what to fix before I continue.
 
 _Claude Code following the prompt and confirming the connected file and layouts._
 
-If the agent cannot see your file, open FileMaker Pro, run the **Connect to MCP** script in your file, and keep the connector Web Viewer open in Browse mode. For the full checklist, see [fmBridge troubleshooting](/docs/webviewer/fm-bridge#troubleshooting).
+If the agent cannot see your file, confirm the **Connect to MCP** script is running and the connector Web Viewer is still open in Browse mode. For the full checklist, see [fmBridge troubleshooting](/docs/webviewer/fm-bridge#troubleshooting).
 
 ## Next step
 


### PR DESCRIPTION
## Summary
- Clarifies that FileMaker users must run the **Connect to MCP** script after adding the ProofKit add-on.
- Splits the AI getting started path into install/add-on and connect/verify steps.

## Test plan
- [x] pnpm run ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redesigned AI getting-started guide: replaced the four-step flow with a clearer five-step path (Install, Connect/Verify, Explore, Build, Deploy), updated the intro and callout wording.
  * Added a dedicated step to run the connector and guidance to keep it open while enabling the plug‑in if prompted.
  * Updated troubleshooting to confirm the connector/script is running and the viewer remains in Browse mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->