### PR TITLE
docs: align LICENSE copyright with Proof+Geist legal entity

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Proof
+Copyright (c) 2025-2026 Proof+Geist, Inc., d/b/a Proof Systems & Humans
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Updates `LICENSE.md` so the MIT copyright line identifies the full legal entity:

```diff
- Copyright (c) 2025 Proof
+ Copyright (c) 2025-2026 Proof+Geist, Inc., d/b/a Proof Systems & Humans
```

Two changes in one line:

1. **Entity name** — uses the legal entity (`Proof+Geist, Inc.`) plus the d/b/a (`Proof Systems & Humans`). The DBA was filed as part of the proof.sh migration (Phase 1); the legal entity name is unchanged. This matches the convention applied across the [proof-legal-documents repo in `b23d7a4`](https://github.com/proofsh/proof-legal-documents/commit/b23d7a4): first entity mention identifies both, subsequent references use the short form.
2. **Year range** — expanded `2025` → `2025-2026` to reflect ongoing 2026 contributions to this repo.

## Context

The proof-legal-documents repo recently added a [ProofKit OSS carve-out to the Standard EULA + Supplement](https://github.com/proofsh/proof-legal-documents) that points to this repo as the source of truth for the MIT-licensed portion of ProofKit's binary. With that cross-reference now in place, having the LICENSE here use a different copyright string (`Proof` vs. `Proof+Geist, Inc., d/b/a Proof Systems & Humans`) creates a small inconsistency for anyone reading both. This PR closes that gap.

## Test plan

- [ ] Visual check: `LICENSE.md` renders correctly on the GitHub repo page
- [ ] No code, build, or runtime impact — text-only change to a license file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year range and organization name in LICENSE.md.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->