### PR TITLE
docs: update installer restart guidance

### DIFF
--- a/apps/docs/content/docs/ai/install-and-connect.mdx
+++ b/apps/docs/content/docs/ai/install-and-connect.mdx
@@ -17,7 +17,9 @@ ProofKit installs several pieces that work together: a FileMaker add-on, a FileM
   <Step>
     **Download and run the installer.**
 
-    Get the installer for your platform: [macOS](/download/mac) or [Windows](/download/win). The installer sets up the local ProofKit tools and registers integrations for supported coding agents.
+    Before you run it, quit FileMaker Pro and your coding agent, such as Claude Desktop. Then get the installer for your platform: [macOS](/download/mac) or [Windows](/download/win). The installer sets up the local ProofKit tools and registers integrations for supported coding agents.
+
+    After the installer finishes, reopen FileMaker Pro and your coding agent so they load the new ProofKit plug-in and integrations.
   </Step>
 
   <Step>


### PR DESCRIPTION
## Summary
- Clarifies that FileMaker Pro and the coding agent should be quit before running the installer.
- Adds guidance to reopen both apps after installation so the new ProofKit plug-in and integrations load.

## Test plan
- pnpm run ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to include explicit steps for quitting and reopening FileMaker Pro and your coding agent before and after running the ProofKit installer to ensure proper plug-in and integration loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->