### PR TITLE
docs: add walkthrough videos and fix deploy prompt

### DIFF
--- a/apps/docs/content/docs/ai/build-a-webviewer-app.mdx
+++ b/apps/docs/content/docs/ai/build-a-webviewer-app.mdx
@@ -5,6 +5,8 @@ description: Scaffold and iterate on a FileMaker Web Viewer app with your coding
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 
+<YouTubeVideo title="Walkthrough: build a Web Viewer app end to end" url="https://youtu.be/jt3RUTxHoYU" />
+
 After ProofKit is connected and your agent understands the file, switch from exploration to building. The goal is a local web project that previews in the browser and can later be deployed into FileMaker.
 
 ## Build loop

--- a/apps/docs/content/docs/ai/deploy-to-filemaker.mdx
+++ b/apps/docs/content/docs/ai/deploy-to-filemaker.mdx
@@ -5,6 +5,8 @@ description: Bundle your Web Viewer app and deploy it into a FileMaker file.
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 
+<YouTubeVideo title="Walkthrough: deploy your Web Viewer app to FileMaker" url="https://youtu.be/zgFb3RKmIQc" />
+
 Deployment for a ProofKit Web Viewer app means bundling the web app and storing it in your FileMaker file so it can load inside a Web Viewer layout.
 
 This is different from deploying a browser app to a hosting provider. The deployed artifact is HTML and JavaScript living in the FileMaker file.
@@ -14,7 +16,7 @@ This is different from deploying a browser app to a hosting provider. The deploy
 Once the app works locally and FileMaker is connected to ProofKit, you can ask the agent to handle deployment for you:
 
 ```text title="Prompt"
-Deploy the app to my connected file maker file.
+Deploy the app to my connected FileMaker file.
 ```
 
 The agent should treat deployment as a release step, not just a file copy. It should run available checks, build the production bundle, deploy the generated HTML through ProofKit, and then verify the result inside FileMaker.

--- a/apps/docs/content/docs/ai/explore-your-file.mdx
+++ b/apps/docs/content/docs/ai/explore-your-file.mdx
@@ -5,6 +5,8 @@ description: Use chat mode to understand your FileMaker schema before building.
 
 import { Callout } from "fumadocs-ui/components/callout";
 
+<YouTubeVideo title="Walkthrough: explore your FileMaker file in chat" url="https://youtu.be/de1h8LwWBg8" />
+
 Before you build a Web Viewer app, use your agent to explore the FileMaker file. This gives you immediate value from ProofKit and confirms that the agent has useful context.
 
 This page focuses on the exploratory side of ProofKit. To understand how chat-first exploration differs from building an app in a coding agent, see [Chat Mode vs Code Mode](/docs/ai/chat-vs-code-mode).


### PR DESCRIPTION
This change embeds short YouTube walkthroughs on the AI documentation pages for exploring a file, building a Web Viewer app, and deploying to FileMaker. Readers can follow the same flows visually alongside the written steps. The sample deploy prompt now uses correct FileMaker capitalization so copy-paste matches product naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added embedded YouTube walkthrough videos to AI documentation pages for visual guidance on building web viewer apps, deploying to FileMaker, and exploring FileMaker files in chat.
  * Improved FileMaker documentation text clarity with corrected capitalization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proofsh/proofkit/pull/253)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->