### PR TITLE
docs: Next/Image logo sizing + AI guides

### DIFF
--- a/apps/docs/content/docs/ai/deploy-to-filemaker.mdx
+++ b/apps/docs/content/docs/ai/deploy-to-filemaker.mdx
@@ -63,4 +63,6 @@ Users of the deployed app do not need ProofKit installed. ProofKit is needed dur
 
 ## Next step
 
-Read [Agent Workflow](/docs/ai/agent-workflow) to understand how deployment fits into the larger read, write, verify, and fix loop.
+Continue with [Edit your app](/docs/ai/edit-your-app) for source vs bundled Web Viewer HTML and how to redeploy updates.
+
+Then read [Agent Workflow](/docs/ai/agent-workflow) to understand how deployment fits into the larger read, write, verify, and fix loop.

--- a/apps/docs/content/docs/ai/edit-your-app.mdx
+++ b/apps/docs/content/docs/ai/edit-your-app.mdx
@@ -1,0 +1,26 @@
+---
+title: Edit your app
+description: Work on Web Viewer source in your project, then rebuild and redeploy the bundle into FileMaker.
+---
+
+
+<YouTubeVideo title="Walkthrough: edit source and redeploy your Web Viewer app" url="https://youtu.be/U9NG-1xdCMY" />
+
+After you deploy, you will iterate on **source code**, not inside the Web Viewer HTML stored in FileMaker.
+
+## Where your code actually lives
+
+- **Your project folder (on disk, usually in Git)** is the source of truth. React components, TypeScript files, Tailwind styles, and build configuration all live here. Your coding agent and editor work against this folder.
+- **Inside FileMaker** you have a **built bundle**: the single-file HTML (and embedded assets) that ProofKit writes when you deploy. That artifact runs in the Web Viewer; it is the output of a build, not a comfortable place to hand-edit layouts or scripts.
+
+If you are used to building everything directly in FileMaker, it helps to separate these two mentally: FileMaker hosts the runtime bundle; your machine hosts the editable app.
+
+## The change loop
+
+1. Open the **same Web Viewer project** in your coding agent (the folder created when you scaffolded the app).
+2. **Ask for changes** — new screens, UX tweaks, data wiring, styling. Use the **local preview** so you see updates before touching FileMaker, as described in [Build a Web Viewer App](/docs/ai/build-a-webviewer-app).
+3. When you are satisfied, **build and redeploy** so FileMaker receives a fresh bundle, as in [Deploy to FileMaker](/docs/ai/deploy-to-filemaker). Redeployment replaces the stored artifact users load in the Web Viewer.
+
+Changing FileMaker layouts, scripts, or fields may require **regenerating types** — see [TypeGen](/docs/typegen) when metadata changes.
+
+For how agents iterate with checks and verification, see [Agent Workflow](/docs/ai/agent-workflow).

--- a/apps/docs/content/docs/ai/getting-started.mdx
+++ b/apps/docs/content/docs/ai/getting-started.mdx
@@ -1,13 +1,13 @@
 ---
 title: Getting Started
-description: Follow the ProofKit AI path from install to deployed Web Viewer app.
+description: ProofKit AI path from install through deploy, editing source, and redeploying updates.
 ---
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 
-This page is the overview for the ProofKit v2 happy path. Use it to understand the sequence: install ProofKit, connect and verify your FileMaker file, explore your file, build a Web Viewer app, and deploy it back into FileMaker.
+This page is the overview for the ProofKit v2 happy path. Use it to understand the sequence: install ProofKit and connect MCP, explore your FileMaker file with your agent, build a Web Viewer app, deploy it into FileMaker, then keep working in your source project and redeploy when ready.
 
-Each step below links to a focused guide with the detailed walkthrough. Those guides are where you will find the step-by-step instructions and companion videos for install, exploration, Web Viewer development, deployment, and related workflows.
+Each step below maps to **one guide**: install and connect (single walkthrough), explore, build, deploy, and editing after deploy — with detailed instructions and companion videos where available.
 
 ## Before you start
 
@@ -25,19 +25,11 @@ See [Technical Requirements](/docs/ai/technical-requirements) for the full suppo
 
 <Steps>
   <Step>
-    **Install ProofKit and add it to your FileMaker file.**
+    **Install ProofKit, connect MCP, and verify your file.**
 
-    Run the installer and add the ProofKit add-on to your file.
+    Run the installer and add-on, run **Connect to MCP** in FileMaker Pro, keep the connector Web Viewer open in Browse mode, and ask your agent to confirm it sees your open file.
 
-    Continue with [Install and Connect](/docs/ai/install-and-connect).
-  </Step>
-
-  <Step>
-    **Connect your FileMaker file to MCP and verify it.**
-
-    Run the **Connect to MCP** script in FileMaker Pro, keep the connector Web Viewer open in Browse mode, and ask your agent to confirm it can see the open file.
-
-    Continue with [Install and Connect](/docs/ai/install-and-connect#verify-the-connection).
+    Continue with [Install and Connect](/docs/ai/install-and-connect) (covers install through verification).
   </Step>
 
   <Step>
@@ -63,11 +55,20 @@ See [Technical Requirements](/docs/ai/technical-requirements) for the full suppo
 
     Continue with [Deploy to FileMaker](/docs/ai/deploy-to-filemaker).
   </Step>
+
+  <Step>
+    **Edit source and redeploy.**
+
+    Iterate on your project on disk — that is where your React and TypeScript source lives — then build and redeploy the bundle stored in FileMaker whenever you want users to pick up changes.
+
+    Continue with [Edit your app](/docs/ai/edit-your-app).
+  </Step>
 </Steps>
 
 ## What to read next
 
-- [Install and Connect](/docs/ai/install-and-connect) is the first step in the walkthrough.
+- [Install and Connect](/docs/ai/install-and-connect) covers installer, MCP connection, and verification.
+- [Edit your app](/docs/ai/edit-your-app) separates source projects from bundles stored in FileMaker.
 - [Agent Workflow](/docs/ai/agent-workflow) explains the read, write, verify, and fix loop.
 - [Hybrid Apps](/docs/webviewer) explains the runtime model.
 - [FAQ](/docs/ai/faq) answers common scope, cost, and platform questions.

--- a/apps/docs/content/docs/ai/index.mdx
+++ b/apps/docs/content/docs/ai/index.mdx
@@ -14,7 +14,7 @@ If you're new, follow the guided path below. The package docs are here when you 
 
 <Cards>
   <Card href="/docs/ai/getting-started" title="Getting Started">
-    Install ProofKit, connect your file, build an app, and deploy it into FileMaker.
+    Install ProofKit, connect your file, build an app, deploy it, then edit source and redeploy into FileMaker.
   </Card>
   <Card href="/docs/ai/agent-workflow" title="Understand the agent loop">
     See how ProofKit helps agents read, write, verify, and fix FileMaker-backed apps.

--- a/apps/docs/content/docs/ai/meta.json
+++ b/apps/docs/content/docs/ai/meta.json
@@ -11,6 +11,7 @@
     "explore-your-file",
     "build-a-webviewer-app",
     "deploy-to-filemaker",
+    "edit-your-app",
     "github-workflow",
     "---Understand---",
     "chat-vs-code-mode",

--- a/apps/docs/src/app/layout.config.tsx
+++ b/apps/docs/src/app/layout.config.tsx
@@ -11,8 +11,20 @@ export const baseOptions = {
   nav: {
     title: (
       <>
-        <Image alt="ProofKit" className="block dark:hidden" height={150} src="/logo-horiz-light.svg" width={96} />
-        <Image alt="ProofKit" className="hidden dark:block" height={150} src="/logo-horiz-dark.svg" width={96} />
+        <Image
+          alt="ProofKit"
+          className="block h-auto w-[96px] dark:hidden"
+          height={150}
+          src="/logo-horiz-light.svg"
+          width={96}
+        />
+        <Image
+          alt="ProofKit"
+          className="hidden h-auto w-[96px] dark:block"
+          height={150}
+          src="/logo-horiz-dark.svg"
+          width={96}
+        />
       </>
     ),
   },

--- a/apps/docs/src/components/ProofkitLogo.tsx
+++ b/apps/docs/src/components/ProofkitLogo.tsx
@@ -11,7 +11,7 @@ export const ProofkitLogo: React.FC<ProofkitLogoProps> = ({ alt = "ProofKit", cl
       <Image
         alt=""
         aria-hidden="true"
-        className="h-full w-full dark:hidden"
+        className="h-auto w-full dark:hidden"
         height={804}
         src="/logo-horiz-light.svg"
         width={2585}
@@ -19,7 +19,7 @@ export const ProofkitLogo: React.FC<ProofkitLogoProps> = ({ alt = "ProofKit", cl
       <Image
         alt=""
         aria-hidden="true"
-        className="hidden h-full w-full dark:block"
+        className="hidden h-auto w-full dark:block"
         height={804}
         src="/logo-horiz-dark.svg"
         width={2585}


### PR DESCRIPTION
## Summary
- Fix Next.js `Image` aspect-ratio warnings for ProofKit logos (`ProofkitLogo` and docs nav) by using `h-auto` with explicit width constraints.
- Add **Edit your app** AI doc and refresh AI section navigation and related pages.

## Test plan
- [x] `pnpm run ci` (local)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new guide for editing and redeploying Web Viewer apps.
  * Updated Getting Started guide to reflect the updated development workflow.
  * Enhanced deployment documentation with clearer navigation paths.
  * Updated site navigation to include the new edit guide.

* **Style**
  * Improved logo rendering with enhanced dark/light theme support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proofsh/proofkit/pull/254)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->