### PR TITLE
feat(docs): homepage promo video lightbox and hero updates

### DIFF
--- a/apps/docs/src/app/(home)/page.tsx
+++ b/apps/docs/src/app/(home)/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import DarkVeil from "@/components/DarkVeil";
 import { DownloadButton } from "@/components/DownloadButton";
 import { ExampleShowcaseGrid } from "@/components/examples/ExampleShowcaseGrid";
+import { HeroPromoVideo } from "@/components/HeroPromoVideo";
 import { MarketingNav } from "@/components/MarketingNav";
 import { MarketingCard, MarketingSection } from "@/components/marketing-section";
 import { ProofkitLogo } from "@/components/ProofkitLogo";
@@ -10,6 +11,7 @@ import { ProofLogo } from "@/components/ProofLogo";
 import { ClaudeAiIcon } from "@/components/ui/svgs/claudeAiIcon";
 import { CodexDark } from "@/components/ui/svgs/codexDark";
 import { CursorDark } from "@/components/ui/svgs/cursorDark";
+import { heroDarkSecondaryPillClassName } from "@/lib/hero-dark-secondary-pill";
 import { getMarketingMetadata } from "@/lib/og";
 
 export const metadata = getMarketingMetadata("home");
@@ -85,13 +87,13 @@ export default function HomePage() {
 
                 <div className="mt-10 flex flex-col items-center justify-center gap-4">
                   <DownloadButton variant="dark" />
-                  <Link
-                    className="inline-flex items-center gap-1.5 font-medium text-sm text-white/60 underline-offset-4 transition hover:text-white hover:underline"
-                    href="/docs/ai/getting-started"
-                  >
-                    Read the Getting Started guide
-                    <ArrowRight className="size-4" />
-                  </Link>
+                  <div className="flex flex-col items-center gap-3 sm:flex-row sm:flex-wrap sm:justify-center sm:gap-x-6 sm:gap-y-2">
+                    <HeroPromoVideo />
+                    <Link className={heroDarkSecondaryPillClassName} href="/docs/ai/getting-started">
+                      Read the Getting Started guide
+                      <ArrowRight className="size-4" />
+                    </Link>
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/docs/src/components/HeroPromoVideo.tsx
+++ b/apps/docs/src/components/HeroPromoVideo.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Play } from "lucide-react";
+import { useState } from "react";
+import { flushSync } from "react-dom";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { getYouTubeNocookieEmbedSrc, YouTubeVideo } from "@/components/YouTubeVideo";
+import { trackPromoVideoClosed, trackPromoVideoOpened } from "@/lib/analytics";
+import { heroDarkSecondaryPillClassName } from "@/lib/hero-dark-secondary-pill";
+import { cn } from "@/lib/utils";
+
+const PROMO_VIDEO_URL = "https://youtu.be/9ESJLc1dUbQ";
+const PROMO_VIDEO_ID = "9ESJLc1dUbQ";
+const SURFACE = "home_hero";
+
+interface HeroPromoVideoProps {
+  className?: string;
+}
+
+export function HeroPromoVideo({ className }: HeroPromoVideoProps) {
+  const [open, setOpen] = useState(false);
+  const [embedSrc, setEmbedSrc] = useState<string | null>(null);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      trackPromoVideoClosed({ video_id: PROMO_VIDEO_ID, surface: SURFACE });
+      setEmbedSrc(null);
+    }
+    setOpen(next);
+  };
+
+  const openDialog = () => {
+    trackPromoVideoOpened({
+      video_id: PROMO_VIDEO_ID,
+      surface: SURFACE,
+      video_url: PROMO_VIDEO_URL,
+    });
+    const src = getYouTubeNocookieEmbedSrc({
+      url: PROMO_VIDEO_URL,
+      autoPlay: true,
+      origin: window.location.origin,
+    });
+    flushSync(() => {
+      setEmbedSrc(src);
+      setOpen(true);
+    });
+  };
+
+  return (
+    <>
+      <button
+        aria-haspopup="dialog"
+        className={cn(heroDarkSecondaryPillClassName, className)}
+        onClick={openDialog}
+        type="button"
+      >
+        <Play aria-hidden className="size-4 shrink-0 fill-current" />
+        Watch overview
+      </button>
+
+      <Dialog onOpenChange={handleOpenChange} open={open}>
+        <DialogContent
+          className={cn(
+            "max-w-[min(100vw-2rem,85rem)] gap-0 overflow-hidden border-2 border-white bg-black p-0 shadow-2xl",
+            "[&>button]:text-white [&>button]:opacity-90 [&>button]:hover:opacity-100 [&>button]:focus:ring-white [&>button]:focus:ring-offset-black",
+          )}
+        >
+          <DialogTitle className="sr-only">ProofKit overview video</DialogTitle>
+          {open && embedSrc ? (
+            <YouTubeVideo embedSrc={embedSrc} title="ProofKit overview video" variant="plain" />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/docs/src/components/YouTubeVideo.tsx
+++ b/apps/docs/src/components/YouTubeVideo.tsx
@@ -2,6 +2,15 @@ interface YouTubeVideoProps {
   title: string;
   videoId?: string;
   url?: string;
+  /**
+   * Full iframe `src` (e.g. built during a click handler with `getYouTubeNocookieEmbedSrc`).
+   * When set, `url`, `videoId`, and `autoPlay` are ignored.
+   */
+  embedSrc?: string;
+  /** Append `autoplay`, `playsinline`, and `origin` to the embed URL. */
+  autoPlay?: boolean;
+  /** Inline embed only (no docs card chrome). */
+  variant?: "card" | "plain";
 }
 
 const YOUTUBE_HOSTS = new Set([
@@ -60,22 +69,57 @@ function getYouTubeVideoId({ url, videoId }: Pick<YouTubeVideoProps, "url" | "vi
   throw new Error(`Unable to extract YouTube video ID from URL: ${parsedUrl.href}`);
 }
 
-export function YouTubeVideo(props: YouTubeVideoProps) {
-  const videoId = getYouTubeVideoId(props);
-  const src = `https://www.youtube-nocookie.com/embed/${videoId}`;
+export interface YouTubeEmbedSrcArgs {
+  url?: string;
+  videoId?: string;
+  autoPlay?: boolean;
+  /** Register the embedding origin with YouTube (recommended with autoplay). */
+  origin?: string;
+}
 
-  return (
-    <div className="my-6 overflow-hidden rounded-xl border bg-fd-card shadow-md">
-      <div className="relative aspect-video">
-        <iframe
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-          allowFullScreen
-          className="absolute inset-0 h-full w-full"
-          referrerPolicy="strict-origin-when-cross-origin"
-          src={src}
-          title={props.title}
-        />
-      </div>
+export function getYouTubeNocookieEmbedSrc(args: YouTubeEmbedSrcArgs): string {
+  const videoId = getYouTubeVideoId(args);
+  const embedParams = new URLSearchParams();
+  if (args.autoPlay) {
+    embedParams.set("autoplay", "1");
+    embedParams.set("playsinline", "1");
+  }
+  if (args.origin) {
+    embedParams.set("origin", args.origin);
+  }
+  const qs = embedParams.toString();
+  return qs
+    ? `https://www.youtube-nocookie.com/embed/${videoId}?${qs}`
+    : `https://www.youtube-nocookie.com/embed/${videoId}`;
+}
+
+export function YouTubeVideo(props: YouTubeVideoProps) {
+  const { variant = "card", title, autoPlay = false, embedSrc: embedSrcProp } = props;
+  const src =
+    embedSrcProp ??
+    getYouTubeNocookieEmbedSrc({
+      url: props.url,
+      videoId: props.videoId,
+      autoPlay,
+      origin: autoPlay && typeof window !== "undefined" ? window.location.origin : undefined,
+    });
+
+  const embed = (
+    <div className="relative aspect-video">
+      <iframe
+        allow="accelerometer; autoplay *; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen
+        className="absolute inset-0 h-full w-full"
+        referrerPolicy="strict-origin-when-cross-origin"
+        src={src}
+        title={title}
+      />
     </div>
   );
+
+  if (variant === "plain") {
+    return embed;
+  }
+
+  return <div className="my-6 overflow-hidden rounded-xl border bg-fd-card shadow-md">{embed}</div>;
 }

--- a/apps/docs/src/lib/analytics.ts
+++ b/apps/docs/src/lib/analytics.ts
@@ -40,3 +40,11 @@ export function trackDownloadRequest(properties: { email: string; platform: stri
 export function trackDocsActionClick(properties: { action: string; destination?: string; markdownUrl?: string }) {
   captureEvent("docs_action_clicked", properties);
 }
+
+export function trackPromoVideoOpened(properties: { video_id: string; surface: string; video_url: string }) {
+  captureEvent("promo_video_opened", properties);
+}
+
+export function trackPromoVideoClosed(properties: { video_id: string; surface: string }) {
+  captureEvent("promo_video_closed", properties);
+}

--- a/apps/docs/src/lib/hero-dark-secondary-pill.ts
+++ b/apps/docs/src/lib/hero-dark-secondary-pill.ts
@@ -1,0 +1,6 @@
+import { cn } from "@/lib/utils";
+
+/** Pill chrome for secondary actions on the dark homepage hero (matches primary download tone). */
+export const heroDarkSecondaryPillClassName = cn(
+  "inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-5 py-2.5 font-semibold text-sm text-white no-underline shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-md transition hover:border-white/25 hover:bg-white/[0.1] hover:text-white hover:no-underline",
+);


### PR DESCRIPTION
## Summary
- Homepage hero: `HeroPromoVideo` lightbox with wider dialog and minimal chrome for the YouTube embed.
- Analytics: PostHog `promo_video_opened` / `promo_video_closed` events.
- `YouTubeVideo`: nocookie embed URL helper, autoplay/playsinline + origin, `plain` variant for modal use.
- Hero CTAs: rebalance with secondary pill styling alongside the promo trigger.

## Testing
- `pnpm run ci` (local, pre-push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added promotional video functionality to the homepage—users can click a button to view an overview video in a dialog.
  * Enhanced the video embedding component with customizable display variants and autoplay support.

* **Chores**
  * Added analytics event tracking for video interactions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proofsh/proofkit/pull/255)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->