### PR TITLE
docs: update homepage promo YouTube link

### DIFF
--- a/apps/docs/src/components/HeroPromoVideo.tsx
+++ b/apps/docs/src/components/HeroPromoVideo.tsx
@@ -9,8 +9,8 @@ import { trackPromoVideoClosed, trackPromoVideoOpened } from "@/lib/analytics";
 import { heroDarkSecondaryPillClassName } from "@/lib/hero-dark-secondary-pill";
 import { cn } from "@/lib/utils";
 
-const PROMO_VIDEO_URL = "https://youtu.be/9ESJLc1dUbQ";
-const PROMO_VIDEO_ID = "9ESJLc1dUbQ";
+const PROMO_VIDEO_URL = "https://youtu.be/dj3fn3RKeQ0";
+const PROMO_VIDEO_ID = "dj3fn3RKeQ0";
 const SURFACE = "home_hero";
 
 interface HeroPromoVideoProps {


### PR DESCRIPTION
## Summary
- Replace the homepage hero promo video URL with the new YouTube link.
- Update the tracked promo video ID to keep analytics metadata aligned.

## Test plan
- [x] Run `npx pnpm@10.27.0 run ci`
- [x] Confirm `apps/docs/src/components/HeroPromoVideo.tsx` uses `https://youtu.be/dj3fn3RKeQ0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the promotional video featured on the documentation site

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proofsh/proofkit/pull/256)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->