### PR TITLE
Remove runtime dev engine from CLI scaffolds

### DIFF
--- a/.changeset/remove-dev-engine-runtime.md
+++ b/.changeset/remove-dev-engine-runtime.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/cli": patch
+---
+
+Remove generated devEngines runtime block and loosen package manager version.

--- a/packages/cli/src/cli/init.ts
+++ b/packages/cli/src/cli/init.ts
@@ -137,11 +137,6 @@ type ProofKitPackageJSON = PackageJson & {
       version: string;
       onFail: "download";
     };
-    runtime: {
-      name: "node";
-      version: string;
-      onFail: "download";
-    };
   };
   engines?: {
     node: string;
@@ -312,12 +307,7 @@ export const runInit = async (name?: string, opts?: CliFlags) => {
     pkgJson.devEngines = {
       packageManager: {
         name: pkgManager,
-        version: pkgManagerVersion,
-        onFail: "download",
-      },
-      runtime: {
-        name: "node",
-        version: NODE_RUNTIME_VERSION,
+        version: pkgManagerVersion.startsWith("^") ? pkgManagerVersion : `^${pkgManagerVersion}`,
         onFail: "download",
       },
     };

--- a/packages/cli/src/core/planInit.ts
+++ b/packages/cli/src/core/planInit.ts
@@ -109,12 +109,7 @@ export function planInit(
       ? {
           packageManager: {
             name: request.packageManager,
-            version: options.packageManagerVersion,
-            onFail: "download",
-          },
-          runtime: {
-            name: "node",
-            version: NODE_RUNTIME_VERSION,
+            version: formatPackageManagerVersionRange(options.packageManagerVersion),
             onFail: "download",
           },
         }
@@ -230,6 +225,10 @@ export function planInit(
       formatPackageManagerCommand(request.packageManager, "proofkit"),
     ],
   };
+}
+
+function formatPackageManagerVersionRange(version: string) {
+  return version.startsWith("^") ? version : `^${version}`;
 }
 
 export function applyPackageJsonMutations(

--- a/packages/cli/src/core/types.ts
+++ b/packages/cli/src/core/types.ts
@@ -111,11 +111,6 @@ export interface InitPlan {
         version: string;
         onFail: "download";
       };
-      runtime: {
-        name: "node";
-        version: string;
-        onFail: "download";
-      };
     };
     engines: {
       node: string;

--- a/packages/cli/tests/init-scaffold-contract.test.ts
+++ b/packages/cli/tests/init-scaffold-contract.test.ts
@@ -181,11 +181,7 @@ describe("Init scaffold contract tests", () => {
     expect(packageJson.devEngines?.packageManager?.name).toBe("pnpm");
     expect(packageJson.devEngines?.packageManager?.version).toMatch(packageManagerVersionPattern);
     expect(packageJson.devEngines?.packageManager?.onFail).toBe("download");
-    expect(packageJson.devEngines?.runtime).toEqual({
-      name: "node",
-      version: NODE_RUNTIME_VERSION,
-      onFail: "download",
-    });
+    expect(packageJson.devEngines?.runtime).toBeUndefined();
     expect(packageJson.engines?.node).toBe(NODE_RUNTIME_VERSION);
     expect(allProofkitDependenciesUseCurrentVersions(packageJson)).toBe(true);
     expect(readFileSync(join(browserProjectDir, "CLAUDE.md"), "utf-8")).toBe("@AGENTS.md\n");
@@ -245,11 +241,7 @@ describe("Init scaffold contract tests", () => {
     expect(packageJson.devEngines?.packageManager?.name).toBe("pnpm");
     expect(packageJson.devEngines?.packageManager?.version).toMatch(packageManagerVersionPattern);
     expect(packageJson.devEngines?.packageManager?.onFail).toBe("download");
-    expect(packageJson.devEngines?.runtime).toEqual({
-      name: "node",
-      version: NODE_RUNTIME_VERSION,
-      onFail: "download",
-    });
+    expect(packageJson.devEngines?.runtime).toBeUndefined();
     expect(packageJson.engines?.node).toBe(NODE_RUNTIME_VERSION);
     expect(allProofkitDependenciesUseCurrentVersions(packageJson)).toBe(true);
     expect(readFileSync(join(webviewerProjectDir, "CLAUDE.md"), "utf-8")).toBe("@AGENTS.md\n");

--- a/packages/cli/tests/integration.test.ts
+++ b/packages/cli/tests/integration.test.ts
@@ -70,14 +70,10 @@ describe("integration scaffold generation", () => {
     expect(packageJson.packageManager).toBeUndefined();
     expect(packageJson.devEngines?.packageManager).toEqual({
       name: "pnpm",
-      version: "11.1.0",
+      version: "^11.1.0",
       onFail: "download",
     });
-    expect(packageJson.devEngines?.runtime).toEqual({
-      name: "node",
-      version: NODE_RUNTIME_VERSION,
-      onFail: "download",
-    });
+    expect(packageJson.devEngines?.runtime).toBeUndefined();
     expect(packageJson.engines).toEqual({
       node: NODE_RUNTIME_VERSION,
     });

--- a/packages/cli/tests/planner.test.ts
+++ b/packages/cli/tests/planner.test.ts
@@ -29,14 +29,10 @@ describe("planInit", () => {
     expect(plan.packageJson.name).toBe("demo-app");
     expect(plan.packageJson.devEngines?.packageManager).toEqual({
       name: "pnpm",
-      version: "11.0.0",
+      version: "^11.0.0",
       onFail: "download",
     });
-    expect(plan.packageJson.devEngines?.runtime).toEqual({
-      name: "node",
-      version: NODE_RUNTIME_VERSION,
-      onFail: "download",
-    });
+    expect(plan.packageJson.devEngines).not.toHaveProperty("runtime");
     expect(plan.packageJson.engines).toEqual({
       node: NODE_RUNTIME_VERSION,
     });


### PR DESCRIPTION
**Summary**
- Drop the generated `devEngines.runtime` block from new ProofKit apps.
- Keep `engines.node` in place and keep package manager dev engines, now written as caret ranges.
- Update CLI planner, init path, and scaffold contract tests to match the new output.

**Testing**
- Added and updated CLI tests covering planner output, integration scaffolds, and scaffold contract output.
- `pnpm run ci` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary Node runtime configuration from generated package.json files in scaffolds.
  * Standardized package manager version formatting to consistently use caret ranges (e.g., ^11.1.0).

* **Chores**
  * Updated test expectations to reflect removal of runtime configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proofsh/proofkit/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->