### PR TITLE
docs(ai): emphasize quitting/restarting FM + agent in install step 1

### DIFF
--- a/apps/docs/content/docs/ai/install-and-connect.mdx
+++ b/apps/docs/content/docs/ai/install-and-connect.mdx
@@ -17,13 +17,13 @@ ProofKit installs several pieces that work together: a FileMaker add-on, a FileM
   <Step>
     **Download and run the installer.**
 
-    Before you run it, quit FileMaker Pro and your coding agent, such as Claude Desktop. Then get the installer for your platform:
+    Before you run it, **fully quit both FileMaker Pro and your coding agent** (Claude Desktop, Cursor, etc.). They must be closed during installation so the new plug-in and integrations register correctly. Then get the installer for your platform:
 
     <DownloadLink />
 
     The installer sets up the local ProofKit tools and registers integrations for supported coding agents.
 
-    After the installer finishes, reopen FileMaker Pro and your coding agent so they load the new ProofKit plug-in and integrations.
+    After the installer finishes, **restart both FileMaker Pro and your coding agent** (Claude Desktop, Cursor, etc.) so they load the new ProofKit plug-in and integrations. Skipping this restart is the most common cause of connection failures.
   </Step>
 
   <Step>


### PR DESCRIPTION
## Summary

- Rewrites step 1 of the AI install flow to explicitly call out that users must **fully quit** both FileMaker Pro and their coding agent (Claude Desktop, Cursor, etc.) before installing the plugin, then **restart both** after.
- Adds a callout noting that skipping the restart is the most common cause of connection failures.
- Wording change only — no code or config altered.

## Test plan

- [ ] Docs build passes (`pnpm build` in `apps/docs`)
- [ ] Eyeball the rendered `install-and-connect` page and confirm step 1 reads clearly
- [ ] Confirm no broken links or MDX parse errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation guide with clearer, more explicit instructions for ProofKit setup. Users are now directed to fully quit both FileMaker Pro and their coding agent before running the installer, and restart both applications afterward to ensure proper plug-in and integration loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proofsh/proofkit/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->