### PR TITLE
docs(ai): simplify install step 1 to post-install restart only

### DIFF
--- a/apps/docs/content/docs/ai/install-and-connect.mdx
+++ b/apps/docs/content/docs/ai/install-and-connect.mdx
@@ -17,13 +17,13 @@ ProofKit installs several pieces that work together: a FileMaker add-on, a FileM
   <Step>
     **Download and run the installer.**
 
-    Before you run it, **fully quit both FileMaker Pro and your coding agent** (Claude Desktop, Cursor, etc.). They must be closed during installation so the new plug-in and integrations register correctly. Then get the installer for your platform:
+    Get the installer for your platform:
 
     <DownloadLink />
 
     The installer sets up the local ProofKit tools and registers integrations for supported coding agents.
 
-    After the installer finishes, **restart both FileMaker Pro and your coding agent** (Claude Desktop, Cursor, etc.) so they load the new ProofKit plug-in and integrations. Skipping this restart is the most common cause of connection failures.
+    When it finishes, **fully restart both FileMaker Pro and your coding agent** (Claude Desktop, Cursor, etc.) so they pick up the new plug-in and integrations. Skipping this restart is the most common cause of connection failures.
   </Step>
 
   <Step>


### PR DESCRIPTION
## Summary

- Removes the redundant pre-install "quit both apps" guidance from install step 1
- The post-install restart already covers loading the new plug-in and integrations, so the quit-before instruction was unnecessary
- Follow-up to #275, which originally introduced both the quit-before and restart-after steps

## Test plan

- [ ] Verify docs build passes (`pnpm build` in `apps/docs`)
- [ ] Eyeball the install-and-connect page to confirm the simplified step reads naturally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised ProofKit installation instructions with updated guidance on obtaining platform-specific installers and clarified post-installation procedures requiring a full restart of the application and coding agent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proofsh/proofkit/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->