### PR TITLE
fix: link Claude Desktop in AI getting-started docs

### DIFF
--- a/apps/docs/content/docs/ai/getting-started.mdx
+++ b/apps/docs/content/docs/ai/getting-started.mdx
@@ -13,7 +13,7 @@ Each step below maps to **one guide**: install and connect (single walkthrough),
 
 Ensure you have the following prerequisites installed on your computer before installing ProofKit.
 - FileMaker Pro (client for Mac or Windows)
-- MCP-compatible coding agent (e.g. [Cursor](https://cursor.com), [Claude](https://claude.ai), [Codex](https://chatgpt.com/codex/), etc.)
+- MCP-compatible coding agent (e.g. [Cursor](https://cursor.com), [Claude Desktop](https://claude.com/download), [Codex](https://chatgpt.com/codex/), etc.)
 - [Node.js](https://nodejs.org/en/download/) (a supported LTS release, such as 22.x, 24.x, or 26.x)
 - [pnpm](https://pnpm.io/) (version 11 is recommended; it is currently the most secure package manager option)
 - Git (source control tool for managing the web code your agent will produce)


### PR DESCRIPTION
Fix the "Before you start" link in `apps/docs/content/docs/ai/getting-started.mdx` to point to Claude Desktop (`https://claude.com/download`) instead of claude.ai.

Commit: 650d9ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started guide prerequisites with the correct download page reference for MCP-compatible coding agents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proofsh/proofkit/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->