### PR TITLE
docs(ai): add Pi to manual MCP setup

### DIFF
--- a/apps/docs/content/docs/ai/manual-mcp-setup.mdx
+++ b/apps/docs/content/docs/ai/manual-mcp-setup.mdx
@@ -44,7 +44,7 @@ Every supported agent uses the same logical server entry. The only differences a
 
 Open the config file for your agent, add the server entry under the correct wrapper key, save, and restart the agent.
 
-<Tabs items={["Claude Desktop", "Claude Code", "Cursor", "Codex", "VS Code", "Windsurf", "Gemini CLI"]}>
+<Tabs items={["Claude Desktop", "Claude Code", "Cursor", "Codex", "VS Code", "Windsurf", "Gemini CLI", "Pi"]}>
   <Tab value="Claude Desktop">
     **Config file**
 
@@ -186,11 +186,48 @@ Open the config file for your agent, add the server entry under the correct wrap
 
     Restart the Gemini CLI session after saving.
   </Tab>
+
+  <Tab value="Pi">
+    [Pi](https://pi.dev) does not ship built-in MCP support, so it cannot launch `proofkit-mcp` on its own. Install a community MCP-bridge extension first, then point it at ProofKit.
+
+    **Step 1 — Install an MCP adapter extension.**
+
+    ```sh
+    pi install npm:pi-mcp-adapter
+    ```
+
+    **Config file:** `~/.pi/agent/mcp.json`
+
+    **Wrapper key:** `mcpServers`
+
+    ```json
+    {
+      "mcpServers": {
+        "proofkit-mcp": {
+          "command": "/Users/you/.local/bin/proofkit-mcp",
+          "args": [],
+          "env": {},
+          "lifecycle": "eager",
+          "directTools": true
+        }
+      }
+    }
+    ```
+
+    The `lifecycle` and `directTools` fields are adapter options, not part of the shared
+    server entry: `lifecycle: "eager"` connects to your open FileMaker file at startup, and
+    `directTools: true` registers the ProofKit tools as first-class Pi tools instead of
+    hiding them behind a proxy. Both are optional.
+
+    Restart Pi (or run `/reload`) after saving.
+  </Tab>
 </Tabs>
 
 ## Other MCP-compatible agents
 
 Any agent that speaks MCP over stdio can run ProofKit. The agent only needs to launch the `proofkit-mcp` binary as a child process and talk to it with the MCP protocol. Follow your agent's documentation for how to add an MCP server and use the **shared server entry** above as the values.
+
+Some agents — such as [Pi](https://pi.dev) — do not include MCP support out of the box. For those, install a community MCP-bridge extension first (see the **Pi** tab above for an example), then give it the shared server entry.
 
 <Callout type="info" title="Tip">
   If your agent supports the standard `mcpServers` wrapper key (Claude Desktop, Cursor, Windsurf, Gemini CLI all use it), the Claude Desktop snippet is a safe starting point.


### PR DESCRIPTION
## What

Adds [Pi](https://pi.dev) to the **Manual MCP Setup** docs page (`apps/docs/content/docs/ai/manual-mcp-setup.mdx`):

- A new **Pi** tab in the per-agent config Tabs.
- A note in the *Other MCP-compatible agents* section about agents that lack built-in MCP.

## Why

Pi is unique among the listed agents: it ships **no built-in MCP support**, so the page's existing generic advice ("use the shared server entry") doesn't work on its own. Pi users need to install a community MCP-bridge extension first, then point it at `proofkit-mcp`.

## Details

The Pi tab documents:
1. Installing an adapter: `pi install npm:pi-mcp-adapter`
2. The server entry in `~/.pi/agent/mcp.json` using the standard `mcpServers` wrapper key — same shape as the other agents.
3. Two optional adapter-specific fields (`lifecycle: "eager"` and `directTools: true`), clearly called out as adapter options rather than part of the shared server entry.

## Verification

Set this up locally end-to-end: installed `pi-mcp-adapter`, added the `proofkit-mcp` entry to `~/.pi/agent/mcp.json`, restarted Pi, and confirmed the connection — `connectedFiles` returned the open file and `layout_metadata` returned the full layout catalog. The 16 ProofKit tools register as first-class Pi tools with `directTools: true`.

Docs-only change; `@proofkit/docs` is in the changeset ignore list, so no changeset included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated manual MCP setup documentation to add Pi as a supported per-agent configuration target. Includes setup instructions, MCP-bridge adapter integration guidance with installation examples, Pi-specific configuration details, file locations, wrapper key information, and optional configuration fields for extended customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->