### PR TITLE
Retry fmFetch when FileMaker bridge is briefly unavailable

### DIFF
--- a/.changeset/fuzzy-trees-fetch.md
+++ b/.changeset/fuzzy-trees-fetch.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/webviewer": patch
+---
+
+Retry fmFetch when FileMaker bridge is briefly unavailable.

--- a/.changeset/fuzzy-trees-fetch.md
+++ b/.changeset/fuzzy-trees-fetch.md
@@ -2,4 +2,4 @@
 "@proofkit/webviewer": patch
 ---
 
-Retry fmFetch when FileMaker bridge is briefly unavailable.
+Retry fmFetch when FileMaker bridge is briefly unavailable and keep callback-mode dispatch failures catchable.

--- a/packages/webviewer/src/main.ts
+++ b/packages/webviewer/src/main.ts
@@ -39,16 +39,10 @@ export function fmFetch(
    * @param cb callback function to call when the script is done
    */
   callback: () => void,
-): void;
+): Promise<void>;
 export function fmFetch(scriptName: string, data: string | object, callback?: () => void) {
   if (callback) {
-    const pendingScript = _execScriptWithFileMakerRetry(scriptName, data, callback);
-    pendingScript.catch((error: unknown) => {
-      setTimeout(() => {
-        throw error;
-      }, 0);
-    });
-    return;
+    return _execScriptWithFileMakerRetry(scriptName, data, callback);
   }
   return new Promise((resolve, reject) => {
     _execScriptWithFileMakerRetry(scriptName, data, (result) => {

--- a/packages/webviewer/src/main.ts
+++ b/packages/webviewer/src/main.ts
@@ -1,6 +1,9 @@
 import { v4 } from "uuid";
 
 let webViewerName: string;
+const FM_FETCH_FILEMAKER_RETRY_DELAYS_MS = [250, 500, 1000] as const;
+const FILEMAKER_UNAVAILABLE_MESSAGE = "'window.FileMaker' was not available";
+
 /**
  * @private
  * set the name of the Web Viewer to use for all fetches
@@ -39,12 +42,18 @@ export function fmFetch(
 ): void;
 export function fmFetch(scriptName: string, data: string | object, callback?: () => void) {
   if (callback) {
-    return _execScript(scriptName, data, callback);
-  }
-  return new Promise((resolve) => {
-    _execScript(scriptName, data, (result) => {
-      resolve(result);
+    const pendingScript = _execScriptWithFileMakerRetry(scriptName, data, callback);
+    pendingScript.catch((error: unknown) => {
+      setTimeout(() => {
+        throw error;
+      }, 0);
     });
+    return;
+  }
+  return new Promise((resolve, reject) => {
+    _execScriptWithFileMakerRetry(scriptName, data, (result) => {
+      resolve(result);
+    }).catch(reject);
   });
 }
 
@@ -83,7 +92,37 @@ function _execScript(scriptName: string, data: unknown, cb: (arg0?: unknown) => 
     data,
     callback: { fetchId, fn: "handleFmWVFetchCallback", webViewerName },
   };
-  callFMScript(scriptName, param);
+  try {
+    callFMScript(scriptName, param);
+  } catch (error) {
+    delete cbs[fetchId];
+    throw error;
+  }
+}
+
+function isFileMakerUnavailableError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes(FILEMAKER_UNAVAILABLE_MESSAGE);
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function _execScriptWithFileMakerRetry(scriptName: string, data: unknown, cb: (arg0?: unknown) => void) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      _execScript(scriptName, data, cb);
+      return;
+    } catch (error) {
+      const delay = FM_FETCH_FILEMAKER_RETRY_DELAYS_MS[attempt];
+      if (!(delay && isFileMakerUnavailableError(error))) {
+        throw error;
+      }
+      await wait(delay);
+    }
+  }
 }
 
 /**

--- a/packages/webviewer/tests/main.test.ts
+++ b/packages/webviewer/tests/main.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("fmFetch", () => {
+  const originalWindow = globalThis.window;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    globalThis.window = {} as Window & typeof globalThis;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (typeof originalWindow === "undefined") {
+      Reflect.deleteProperty(globalThis, "window");
+    } else {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it("retries when FileMaker is not yet available", async () => {
+    const { fmFetch } = await import("../src/main.ts");
+    const performScript = vi.fn();
+
+    const result = fmFetch("LoadData", { id: "123" });
+    globalThis.window.FileMaker = {
+      PerformScript: performScript,
+      PerformScriptWithOption: vi.fn(),
+    };
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(performScript).toHaveBeenCalledTimes(1);
+    const params = JSON.parse(String(performScript.mock.calls[0]?.[1])) as {
+      callback: { fetchId: string };
+    };
+    globalThis.window.handleFmWVFetchCallback(JSON.stringify({ ok: true }), params.callback.fetchId);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(result).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects after three FileMaker availability retries", async () => {
+    const { fmFetch } = await import("../src/main.ts");
+
+    const result = fmFetch("LoadData", { id: "123" });
+    const rejection = expect(result).rejects.toThrow("'window.FileMaker' was not available");
+    await vi.advanceTimersByTimeAsync(1750);
+
+    await rejection;
+  });
+});

--- a/packages/webviewer/tests/main.test.ts
+++ b/packages/webviewer/tests/main.test.ts
@@ -49,4 +49,14 @@ describe("fmFetch", () => {
 
     await rejection;
   });
+
+  it("returns a catchable rejection in callback mode after retries", async () => {
+    const { fmFetch } = await import("../src/main.ts");
+
+    const result = fmFetch("LoadData", { id: "123" }, vi.fn());
+    const rejection = expect(result).rejects.toThrow("'window.FileMaker' was not available");
+    await vi.advanceTimersByTimeAsync(1750);
+
+    await rejection;
+  });
 });


### PR DESCRIPTION
## Summary
- Add retry handling around `fmFetch` when `window.FileMaker` is temporarily unavailable.
- Retry with short backoff before failing, covering both callback and promise usage.
- Add tests for successful recovery and final rejection after retries are exhausted.

Closes #288

## Testing
- `pnpm run ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved `fmFetch` reliability by automatically retrying FileMaker script calls when FileMaker is briefly unavailable, using progressive backoff delays.
- Prevented stale pending callbacks by cleaning up when script invocation fails synchronously.
- Updated error behavior so Promise mode rejects on failure and callback-mode failures remain catchable.

## New Features
- `fmFetch` callback usage now returns a `Promise<void>` to match the retry flow.

## Tests
- Added Vitest coverage for retry success (via callback dispatch) and retry exhaustion (Promise rejection).

## Chores
- Prepared a patch release for the webviewer package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->