### PR TITLE
Fix release workflow needs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,6 @@ jobs:
       - lint
       - typecheck
       - test
-      - cli-smoke
       - fmodata-e2e
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- remove stale cli-smoke release dependency
- fixes workflow validation failure before jobs start

## Test
- pnpm run ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow job dependencies to ensure proper validation sequencing before publishing releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->