### PR TITLE
Add fallback config paths for typegen CLI

### DIFF
--- a/.changeset/quiet-walls-move.md
+++ b/.changeset/quiet-walls-move.md
@@ -1,0 +1,5 @@
+---
+"@proofkit/typegen": patch
+---
+
+Find `proofkit.config.json` and `adt.config.json` when resolving typegen CLI config.

--- a/packages/typegen/src/cli.ts
+++ b/packages/typegen/src/cli.ts
@@ -10,7 +10,11 @@ import { parse } from "jsonc-parser";
 import { getFriendlyTypegenError } from "./cli-errors";
 import { typegenConfig } from "./types";
 
-const defaultConfigPaths = ["proofkit-typegen.config.jsonc", "proofkit-typegen.config.json"];
+const defaultConfigNames = ["proofkit-typegen.config", "proofkit.config", "adt.config"];
+const defaultConfigExtensions = ["jsonc", "json"];
+const defaultConfigPaths = defaultConfigNames.flatMap((configName) =>
+  defaultConfigExtensions.map((extension) => `${configName}.${extension}`),
+);
 const oldConfigPaths = ["fmschema.config.mjs", "fmschema.config.js"];
 interface ConfigArgs {
   configLocation: string;
@@ -276,7 +280,7 @@ function parseEnvs(envPath?: string | undefined) {
   // }
 }
 
-function getConfigPath(configPath?: string): string | null {
+export function getConfigPath(configPath?: string): string | null {
   if (configPath) {
     // If a config path is specified, check if it exists
     try {

--- a/packages/typegen/tests/cli-config.test.ts
+++ b/packages/typegen/tests/cli-config.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getConfigPath } from "../src/cli";
+
+let originalCwd: string;
+let tempDir: string;
+
+describe("typegen cli config lookup", () => {
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "proofkit-typegen-config-"));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  });
+
+  it.each(["proofkit.config.jsonc", "proofkit.config.json"])("finds %s fallback files", (configPath) => {
+    fs.writeFileSync(configPath, "{}", "utf8");
+
+    expect(getConfigPath()).toBe(configPath);
+  });
+
+  it.each(["adt.config.jsonc", "adt.config.json"])("finds %s fallback files", (configPath) => {
+    fs.writeFileSync(configPath, "{}", "utf8");
+
+    expect(getConfigPath()).toBe(configPath);
+  });
+
+  it("prefers existing proofkit typegen configs", () => {
+    fs.writeFileSync("proofkit-typegen.config.json", "{}", "utf8");
+    fs.writeFileSync("proofkit.config.jsonc", "{}", "utf8");
+
+    expect(getConfigPath()).toBe("proofkit-typegen.config.json");
+  });
+
+  it("prefers jsonc before json for the same config name", () => {
+    fs.writeFileSync("proofkit.config.jsonc", "{}", "utf8");
+    fs.writeFileSync("proofkit.config.json", "{}", "utf8");
+
+    expect(getConfigPath()).toBe("proofkit.config.jsonc");
+  });
+});


### PR DESCRIPTION
## Summary
- Resolve `proofkit.config.*` and `adt.config.*` alongside existing typegen config names
- Keep `jsonc` preferred over `json` for each config name
- Add coverage for fallback lookup and priority order

## Testing
- Added unit tests for config resolution order and fallback matches
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Typegen now looks for additional default configuration files, including `proofkit.config` and `adt.config`, with support for both `.jsonc` and `.json` formats.
  * The CLI’s config path resolution is now available for broader use.

* **Tests**
  * Added coverage to verify config discovery order and file preference when multiple valid configuration files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->