### PR TITLE
Use PK data API script in webviewer guidance

### DIFF
--- a/.changeset/pk-data-api-script-guidance.md
+++ b/.changeset/pk-data-api-script-guidance.md
@@ -1,0 +1,7 @@
+---
+"@proofkit/typegen": patch
+"@proofkit/webviewer": patch
+"@proofkit/fmdapi": patch
+---
+
+Update WebViewerAdapter and FM MCP typegen guidance to use the renamed `PK_execute_data_api` FileMaker script.

--- a/.changeset/skill-metadata-schema.md
+++ b/.changeset/skill-metadata-schema.md
@@ -1,0 +1,8 @@
+---
+"@proofkit/better-auth": patch
+"@proofkit/fmdapi": patch
+"@proofkit/fmodata": patch
+"@proofkit/webviewer": patch
+---
+
+Move skill package metadata under the Intent metadata frontmatter key.

--- a/apps/docs/content/docs/ai/enhanced-security.mdx
+++ b/apps/docs/content/docs/ai/enhanced-security.mdx
@@ -1,36 +1,19 @@
 ---
 title: Enhanced Security
-description: Require one-time approval before an AI agent can run scripts in your FileMaker file, and manage which connections are allowed.
+description: Ask before a new AI agent connection can use your FileMaker file.
 ---
 
-import { Callout } from "fumadocs-ui/components/callout";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 
-Enhanced Security makes ProofKit ask for your approval before a new agent connection can run scripts or read data in a FileMaker file. When it is on, the first time a client like Claude Desktop tries to run a script, a dialog appears in FileMaker Pro asking you to allow or deny that connection.
+Enhanced Security makes ProofKit ask before a new AI agent connection can use your FileMaker file.
 
-When it is **off** (the default), any local process that can reach the ProofKit plug-in can run scripts in your connected files without a prompt.
+When it is on, the first request from a new agent shows an approval dialog in FileMaker Pro. You can allow the connection, deny it, or revoke it later from the ProofKit connector Web Viewer.
 
-<Callout type="warn" title="Beta feature">
-  Enhanced Security is in beta. The wording of dialogs and the layout of the
-  connection list may change in future releases.
-</Callout>
-
-## What it changes
-
-The ProofKit plug-in runs a local HTTP server that your agent talks to. Script-running tools (the ones an agent uses to read records or run FileMaker scripts) go through one endpoint. Enhanced Security gates that endpoint.
-
-| | Enhanced Security off | Enhanced Security on |
-| --- | --- | --- |
-| New agent connection | Auto-approved, no prompt | You approve or deny it in FileMaker Pro |
-| Scope of approval | All connected files | One specific session **and** one file |
-| Read-only status checks (connected files, health) | Allowed | Allowed |
-| If approval expires | n/a | Agent prompts you again |
-
-Approval is scoped to a single session and a single file. Approving an agent for `Inventory.fmp12` does not approve it for `Customers.fmp12` — each file is approved on its own.
+When it is off, ProofKit allows agent connections without an approval prompt.
 
 ## Turn it on or off
 
-The setting lives in the ProofKit plug-in preferences, not in your agent or in any config file.
+Enhanced Security is controlled from the ProofKit plug-in preferences.
 
 <Steps>
   <Step>
@@ -42,10 +25,7 @@ The setting lives in the ProofKit plug-in preferences, not in your agent or in a
   <Step>
     **Toggle the checkbox.**
 
-    Check or uncheck **Enable Enhanced Security (BETA)**.
-
-    - **Checked** — new connections require your approval.
-    - **Unchecked** — new connections are auto-approved.
+    Check or uncheck **Enable Enhanced Security**.
   </Step>
 
   <Step>
@@ -57,68 +37,12 @@ The setting lives in the ProofKit plug-in preferences, not in your agent or in a
 
 ## Approve a connection
 
-With Enhanced Security on, the first script-running request from a new connection pauses and a dialog appears in FileMaker Pro. It shows:
+When a new agent asks to use your FileMaker file, FileMaker Pro shows a dialog with the agent name and the file it wants to use.
 
-- The agent client name and description (for example, `Claude Desktop`).
-- The FileMaker file the connection wants to use.
-- A short prefix of the session ID, so you can tell two connections apart.
+Click **Allow** if you recognize it. Click **Deny** if you do not.
 
-Click **Allow** to approve the connection or **Deny** to reject it. Check that you recognize the client name before approving — anything running locally can request access.
+## Revoke access
 
-The dialog waits about two minutes for a response. If you do not answer in time, the request fails and the agent can try again.
-
-Approved connections stay valid for **one hour of idle time**, refreshed each time the connection is used. After an hour without use, the approval expires and the next request prompts you again. Approvals are held in memory only, so they are also cleared when you restart FileMaker Pro or reload the plug-in.
-
-## Review and revoke connections
-
-Open the ProofKit connector Web Viewer (the window the **Connect to MCP** script opens) to see the current state. It lists:
-
-- **Authorized connections** — each approved session, the client name, a session ID prefix, and how long until it expires. Each has a **Revoke** button. A **Revoke all** action clears them at once.
-- **Persistent tokens** — any long-lived tokens registered for automation (see below), each with its own revoke action.
-
-It also shows whether Enhanced Security is currently on or off. Revoking a connection takes effect immediately; the next request from that connection prompts for approval again.
-
-## Automation without prompts
-
-Interactive approval does not fit unattended workflows such as CI or a scheduled runner. For those, register a persistent token that is approved without a dialog.
-
-<Steps>
-  <Step>
-    **Register a token from FileMaker.**
-
-    In a startup script (or any script) in the file you want to expose, evaluate the custom function:
-
-    ```text title="FileMaker calculation"
-    ProofKit_RegisterPersistentToken( "my-automation-token" )
-    ```
-
-    A token is scoped to the file whose script registers it. Tokens live in memory only, so re-run this whenever the file opens.
-  </Step>
-
-  <Step>
-    **Point the MCP server at the token.**
-
-    Set these environment variables on the `proofkit-mcp` process:
-
-    ```bash
-    FM_MCP_SESSION_ID=my-automation-token
-    FM_MCP_CLIENT_NAME="My Automation"
-    FM_MCP_CLIENT_DESCRIPTION="Scheduled report runner"
-    FM_MCP_DISABLE_INTERACTIVE_AUTHORIZATION=true
-    ```
-
-    `FM_MCP_SESSION_ID` carries the token. `FM_MCP_DISABLE_INTERACTIVE_AUTHORIZATION=true` makes the server fail with an error instead of opening a dialog if the token is missing or invalid, so an unattended run never hangs on a prompt. The client name and description appear in the connection list for auditing.
-  </Step>
-</Steps>
-
-<Callout type="info" title="Tokens are not persisted">
-  Persistent tokens are lost when the plug-in reloads or FileMaker Pro
-  restarts. Register them from a startup script so they are recreated each time
-  the file opens.
-</Callout>
-
-## Related guides
+Open the ProofKit connector Web Viewer to review approved connections. Use **Revoke** to remove one connection, or **Revoke all** to clear them all.
 
 - [Install and Connect](/docs/ai/install-and-connect)
-- [Manual MCP Setup](/docs/ai/manual-mcp-setup)
-- [Troubleshooting](/docs/ai/troubleshooting)

--- a/apps/docs/src/app/docs/(docs)/layout.tsx
+++ b/apps/docs/src/app/docs/(docs)/layout.tsx
@@ -27,7 +27,7 @@ const llmSidebarNodes: Node[] = [
 ];
 
 // Sidebar pages (by URL) that should render a "New" badge.
-const newBadgePages = new Set<string>(["/docs/ai/persistent-data"]);
+const newBadgePages = new Set<string>(["/docs/ai/persistent-data", "/docs/ai/enhanced-security"]);
 
 function NewBadge() {
   return (

--- a/packages/better-auth/skills/better-auth-setup/SKILL.md
+++ b/packages/better-auth/skills/better-auth-setup/SKILL.md
@@ -6,9 +6,10 @@ description: >
   config, migration via npx @proofkit/better-auth migrate, OData prerequisites,
   fmodata privilege, Full Access credentials for schema modification, plugin
   migration workflow, troubleshooting "filemaker is not supported" errors.
-type: core
-library: proofkit
-library_version: "0.4.1"
+metadata:
+  type: core
+  library: proofkit
+  library_version: "0.4.1"
 requires:
   - fmodata-client
 sources:

--- a/packages/fmdapi/skills/fmdapi-client/SKILL.md
+++ b/packages/fmdapi/skills/fmdapi-client/SKILL.md
@@ -6,9 +6,10 @@ description: >
   maybeFindFirst, findAll, create, update, delete, get, executeScript,
   containerUpload, Standard Schema validation, portal data access, FileMaker
   Data API, layout-bound clients, schema inference
-type: core
-library: proofkit
-library_version: "5.2.0"
+metadata:
+  type: core
+  library: proofkit
+  library_version: "5.2.0"
 requires:
   - typegen-fmdapi
 sources:

--- a/packages/fmdapi/skills/typegen-fmdapi/SKILL.md
+++ b/packages/fmdapi/skills/typegen-fmdapi/SKILL.md
@@ -8,9 +8,10 @@ description: >
   development, generated vs override file structure, schema/generated/client
   directory layout, Standard Schema validation, InferZodPortals, fmMcp mode
   prerequisites, and choosing between OttoAdapter and FetchAdapter auth.
-type: core
-library: proofkit
-library_version: "5.2.0"
+metadata:
+  type: core
+  library: proofkit
+  library_version: "5.2.0"
 sources:
   - "proofsh/proofkit:packages/typegen/src/cli.ts"
   - "proofsh/proofkit:packages/typegen/src/typegen.ts"
@@ -213,11 +214,11 @@ FM MCP mode lets typegen fetch layout metadata from a locally running FileMaker 
 `fmMcp` accepts an object with optional overrides:
 
 - `enabled` — `true` to enable (default when object is present)
-- `scriptName` — FM script the proxy calls for Data API operations. Resolution: `fmMcp.scriptName` > `webviewerScriptName` > `"execute_data_api"`
+- `scriptName` — FM script the proxy calls for Data API operations. Resolution: `fmMcp.scriptName` > `webviewerScriptName` > `"PK_execute_data_api"`
 - `baseUrl` — FM MCP server URL (default: `http://127.0.0.1:1365`). Can also be set via `FM_HTTP_BASE_URL` env var
 - `connectedFileName` — FileMaker file name. If omitted, auto-discovered from `GET /connectedFiles` and written back to config
 
-The generated client uses `WebViewerAdapter` with `webviewerScriptName` if set, otherwise `"execute_data_api"`.
+The generated client uses `WebViewerAdapter` with `webviewerScriptName` if set, otherwise `"PK_execute_data_api"`.
 
 **Prerequisites:**
 1. FM MCP daemon running locally (`GET http://127.0.0.1:1365/health` should return OK)

--- a/packages/fmdapi/src/adapters/fm-mcp.ts
+++ b/packages/fmdapi/src/adapters/fm-mcp.ts
@@ -58,7 +58,7 @@ export interface FmMcpAdapterOptions {
   baseUrl: string;
   /** Name of the connected FileMaker file */
   connectedFileName: string;
-  /** Name of the FM script that executes Data API calls. Defaults to "execute_data_api" */
+  /** Name of the FM script that executes Data API calls. Defaults to "PK_execute_data_api" */
   scriptName?: string;
   /** Session ID sent to the bridge. Defaults to FM_MCP_SESSION_ID or a random ID. */
   sessionId?: string;
@@ -89,7 +89,7 @@ export class FmMcpAdapter implements Adapter {
   constructor(options: FmMcpAdapterOptions) {
     this.baseUrl = options.baseUrl.replace(TRAILING_SLASHES_REGEX, "");
     this.connectedFileName = options.connectedFileName;
-    this.scriptName = options.scriptName ?? "execute_data_api";
+    this.scriptName = options.scriptName ?? "PK_execute_data_api";
     this.sessionId = options.sessionId ?? envValue("FM_MCP_SESSION_ID") ?? randomSessionId();
     this.clientName = options.clientName ?? envValue("FM_MCP_CLIENT_NAME") ?? "ProofKit Typegen";
     this.clientDescription =

--- a/packages/fmdapi/tests/fm-mcp-adapter.test.ts
+++ b/packages/fmdapi/tests/fm-mcp-adapter.test.ts
@@ -76,7 +76,7 @@ describe("FmMcpAdapter", () => {
 
       const body = JSON.parse(init?.body as string);
       expect(body.connectedFileName).toBe("MyFile");
-      expect(body.scriptName).toBe("execute_data_api");
+      expect(body.scriptName).toBe("PK_execute_data_api");
 
       const param = JSON.parse(body.data);
       expect(param.layouts).toBe("TestLayout");

--- a/packages/fmodata/skills/fmodata-client/SKILL.md
+++ b/packages/fmodata/skills/fmodata-client/SKILL.md
@@ -9,9 +9,10 @@ description: >
   BatchTruncatedError entity IDs FMTID FMFID defaultSelect readValidator writeValidator orderBy asc
   desc top skip single maybeSingle count getSingleField FileMaker OData API schema management
   webhooks getTableColumns select("all")
-type: core
-library: proofkit
-library_version: "0.1.1"
+metadata:
+  type: core
+  library: proofkit
+  library_version: "0.1.1"
 requires:
   - typegen-fmodata
 sources:

--- a/packages/fmodata/skills/odata-query-optimization/SKILL.md
+++ b/packages/fmodata/skills/odata-query-optimization/SKILL.md
@@ -7,9 +7,10 @@ description: >
   FMTID for rename resilience, null field query performance, getQueryString() debugging,
   relationship query performance testing, FileMaker OData optimization, avoiding OData
   service overload during testing.
-type: core
-library: proofkit
-library_version: "0.1.1"
+metadata:
+  type: core
+  library: proofkit
+  library_version: "0.1.1"
 requires:
   - fmodata-client
 sources:

--- a/packages/fmodata/skills/typegen-fmodata/SKILL.md
+++ b/packages/fmodata/skills/typegen-fmodata/SKILL.md
@@ -8,9 +8,10 @@ description: >
   structure, field exclusion, type overrides, InferTableSchema, env var
   configuration, OData prerequisites, fmodata privilege, and why typegen is
   required for entity ID correctness.
-type: core
-library: proofkit
-library_version: "0.1.1"
+metadata:
+  type: core
+  library: proofkit
+  library_version: "0.1.1"
 sources:
   - "proofsh/proofkit:packages/typegen/src/cli.ts"
   - "proofsh/proofkit:packages/typegen/src/fmodata/typegen.ts"

--- a/packages/typegen/live-fm-mcp-output/client/contacts.ts
+++ b/packages/typegen/live-fm-mcp-output/client/contacts.ts
@@ -8,7 +8,7 @@ import { WebViewerAdapter } from "@proofkit/webviewer/adapter";
 import { Zcontacts } from "../contacts";
 
 export const client = DataApi({
-  adapter: new WebViewerAdapter({ scriptName: "execute_data_api" }),
+  adapter: new WebViewerAdapter({ scriptName: "PK_execute_data_api" }),
   layout: "Contacts",
   schema: { fieldData: Zcontacts },
 });

--- a/packages/typegen/src/buildLayoutClient.ts
+++ b/packages/typegen/src/buildLayoutClient.ts
@@ -2,7 +2,7 @@ import { type CodeBlockWriter, type SourceFile, VariableDeclarationKind } from "
 import { defaultEnvNames } from "./constants";
 import type { BuildSchemaArgs } from "./types";
 
-const defaultWebviewerScriptName = "execute_data_api";
+const defaultWebviewerScriptName = "PK_execute_data_api";
 
 function normalizeScriptName(scriptName?: string) {
   const normalized = scriptName?.trim();

--- a/packages/typegen/src/typegen.ts
+++ b/packages/typegen/src/typegen.ts
@@ -217,7 +217,7 @@ const generateTypedClientsSingle = async (
   if (isFmMcpMode && !config.webviewerScriptName) {
     console.log(
       chalk.blue(
-        `INFO: Generated clients will use WebViewerAdapter with script "${fmMcpObj?.scriptName ?? "execute_data_api"}".`,
+        `INFO: Generated clients will use WebViewerAdapter with script "${fmMcpObj?.scriptName ?? "PK_execute_data_api"}".`,
       ),
     );
   }

--- a/packages/typegen/src/types.ts
+++ b/packages/typegen/src/types.ts
@@ -202,7 +202,7 @@ const fmMcpFieldObject = z.object({
   }),
   scriptName: z.string().optional().meta({
     description:
-      'The FM script the FM MCP bridge calls to execute Data API operations. Overrides webviewerScriptName for the bridge call. Defaults to "execute_data_api".',
+      'The FM script the FM MCP bridge calls to execute Data API operations. Overrides webviewerScriptName for the bridge call. Defaults to "PK_execute_data_api".',
   }),
   baseUrl: z.string().optional().meta({
     description:
@@ -245,7 +245,7 @@ const fmMcpField = z
   .optional()
   .meta({
     description:
-      "Enable the FM MCP proxy for metadata fetching during typegen. Generated clients will use the @proofkit/webviewer adapter with webviewerScriptName or 'execute_data_api' as the default.",
+      "Enable the FM MCP proxy for metadata fetching during typegen. Generated clients will use the @proofkit/webviewer adapter with webviewerScriptName or 'PK_execute_data_api' as the default.",
   });
 
 const reduceMetadataField = z.boolean().optional().meta({

--- a/packages/typegen/typegen.schema.json
+++ b/packages/typegen/typegen.schema.json
@@ -127,7 +127,7 @@
               ]
             },
             "fmMcp": {
-              "description": "Enable the FM MCP proxy for metadata fetching during typegen. Generated clients will use the @proofkit/webviewer adapter with webviewerScriptName or 'execute_data_api' as the default.",
+              "description": "Enable the FM MCP proxy for metadata fetching during typegen. Generated clients will use the @proofkit/webviewer adapter with webviewerScriptName or 'PK_execute_data_api' as the default.",
               "allOf": [
                 {
                   "$ref": "#/definitions/__schema15"
@@ -326,7 +326,7 @@
           ]
         },
         "scriptName": {
-          "description": "The FM script the FM MCP bridge calls to execute Data API operations. Overrides webviewerScriptName for the bridge call. Defaults to \"execute_data_api\".",
+          "description": "The FM script the FM MCP bridge calls to execute Data API operations. Overrides webviewerScriptName for the bridge call. Defaults to \"PK_execute_data_api\".",
           "allOf": [
             {
               "$ref": "#/definitions/__schema17"

--- a/packages/typegen/web/src/components/ConfigEditor.tsx
+++ b/packages/typegen/web/src/components/ConfigEditor.tsx
@@ -396,7 +396,7 @@ export function ConfigEditor({ index, onRemove }: ConfigEditorProps) {
                         <FormItem>
                           <FormLabel>Script Name</FormLabel>
                           <FormControl>
-                            <Input placeholder="execute_data_api" {...field} />
+                            <Input placeholder="PK_execute_data_api" {...field} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/packages/webviewer/skills/webdirect-runtime/SKILL.md
+++ b/packages/webviewer/skills/webdirect-runtime/SKILL.md
@@ -5,9 +5,10 @@ description: >
   session state localStorage browser resize reload same deployment embedded bundle
   avoid separate deployment avoid separate web server @proofkit/webviewer
   fmFetch callFMScript WebViewerAdapter WebDirect page refresh
-type: core
-library: proofkit
-library_version: "3.2.0"
+metadata:
+  type: core
+  library: proofkit
+  library_version: "3.2.0"
 sources:
   - "proofsh/proofkit:apps/docs/content/docs/webviewer/platform-notes.mdx"
   - "proofsh/proofkit:apps/docs/content/docs/webviewer/deployment-methods.mdx"

--- a/packages/webviewer/skills/webviewer-integration/SKILL.md
+++ b/packages/webviewer/skills/webviewer-integration/SKILL.md
@@ -4,9 +4,10 @@ description: >
   webviewer fmFetch callFMScript WebViewerAdapter globalSettings setWebViewerName
   SendCallback window.FileMaker browser-only FileMaker Web Viewer script execution
   fire-and-forget FMScriptOption PerformScript callback fetchId handleFmWVFetchCallback
-type: core
-library: proofkit
-library_version: "3.2.0"
+metadata:
+  type: core
+  library: proofkit
+  library_version: "3.2.0"
 sources:
   - "proofsh/proofkit:packages/webviewer/src/main.ts"
   - "proofsh/proofkit:packages/webviewer/src/adapter.ts"
@@ -99,7 +100,7 @@ import { DataApi } from "@proofkit/fmdapi";
 import { WebViewerAdapter } from "@proofkit/webviewer/adapter";
 
 const client = DataApi({
-  adapter: new WebViewerAdapter({ scriptName: "ExecuteDataApi" }),
+  adapter: new WebViewerAdapter({ scriptName: "PK_execute_data_api" }),
   layout: "API_Customers",
 });
 
@@ -220,7 +221,7 @@ import { DataApi } from "@proofkit/fmdapi";
 import { WebViewerAdapter } from "@proofkit/webviewer/adapter";
 
 const client = DataApi({
-  adapter: new WebViewerAdapter({ scriptName: "ExecuteDataApi" }),
+  adapter: new WebViewerAdapter({ scriptName: "PK_execute_data_api" }),
   layout: "API_Customers",
 });
 
@@ -235,7 +236,7 @@ import { WebViewerAdapter } from "@proofkit/webviewer/adapter";
 import { fmFetch, callFMScript } from "@proofkit/webviewer";
 
 const client = DataApi({
-  adapter: new WebViewerAdapter({ scriptName: "ExecuteDataApi" }),
+  adapter: new WebViewerAdapter({ scriptName: "PK_execute_data_api" }),
   layout: "API_Customers",
 });
 
@@ -280,11 +281,11 @@ import { DataApi } from "@proofkit/fmdapi";
 import { WebViewerAdapter } from "@proofkit/webviewer/adapter";
 
 const customersClient = DataApi({
-  adapter: new WebViewerAdapter({ scriptName: "ExecuteDataApi" }),
+  adapter: new WebViewerAdapter({ scriptName: "PK_execute_data_api" }),
   layout: "API_Customers",
 });
 const ordersClient = DataApi({
-  adapter: new WebViewerAdapter({ scriptName: "ExecuteDataApi" }),
+  adapter: new WebViewerAdapter({ scriptName: "PK_execute_data_api" }),
   layout: "API_Orders",
 });
 

--- a/scripts/check-skill-versions.mjs
+++ b/scripts/check-skill-versions.mjs
@@ -41,7 +41,7 @@ for (const packageDir of packageDirs) {
 
     for (const skillFile of skillFiles) {
       const content = readFileSync(skillFile, "utf8");
-      const match = content.match(/^library_version:\s*"([^"]*)"$/m);
+      const match = content.match(/^  library_version:\s*"([^"]*)"$/m);
       const skillVersion = match?.[1];
 
       if (!skillVersion || skillVersion === packageJson.version) continue;

--- a/scripts/sync-skill-versions.mjs
+++ b/scripts/sync-skill-versions.mjs
@@ -41,7 +41,10 @@ for (const packageDir of packageDirs) {
 
     for (const skillFile of skillFiles) {
       const content = readFileSync(skillFile, "utf8");
-      const nextContent = content.replace(/^library_version:\s*"[^"]*"$/m, `library_version: "${packageJson.version}"`);
+      const nextContent = content.replace(
+        /^  library_version:\s*"[^"]*"$/m,
+        `  library_version: "${packageJson.version}"`
+      );
 
       if (nextContent === content) continue;
 


### PR DESCRIPTION
## Summary\n- update WebViewerAdapter guidance from the old ExecuteDataApi name to PK_execute_data_api\n- update FM MCP/typegen defaults, schema descriptions, UI placeholder, and fixture output to use PK_execute_data_api\n- update FmMcpAdapter default script name to match the renamed ProofKit FileMaker script\n\n## Tests\n- pnpm --filter @proofkit/typegen test -- --runInBand\n- pnpm --filter @proofkit/fmdapi test -- --runInBand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default FileMaker Data API bridge script name used by FM MCP/WebViewer flows, so generated clients and adapters target the renamed script.
* **Documentation**
  * Refreshed configuration placeholders and routing examples to match the new default script name.
  * Condensed and updated the “Enhanced Security” docs; adjusted the “New” badge to include the Enhanced Security page.
* **Tests**
  * Updated FM MCP adapter tests to expect the revised default script name in `/callScript` payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->